### PR TITLE
Add optional root backend support and keep fan controls visible in AutoTDP mode

### DIFF
--- a/app/src/main/java/com/kei/pulse/data/PerformanceRepository.kt
+++ b/app/src/main/java/com/kei/pulse/data/PerformanceRepository.kt
@@ -168,7 +168,7 @@ class PerformanceRepository(
 
     suspend fun applyTier(tier: PowerTier): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val policies = resolvePolicies()
         if (policies.isEmpty()) {
@@ -198,7 +198,7 @@ class PerformanceRepository(
      */
     suspend fun restoreCustomValues(): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val policies = resolvePolicies()
         if (policies.isEmpty()) {
@@ -242,7 +242,7 @@ class PerformanceRepository(
     /** Applies a display profile (saved profile or Stock) by id — the tile/per-app entry point. */
     suspend fun applyDisplayProfileById(profileId: String): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val state = observeState().first()
         val profile = state.displayProfiles.firstOrNull { it.id == profileId }
@@ -258,7 +258,7 @@ class PerformanceRepository(
     /** Re-applies a raw frequency snapshot, e.g. restoring pre-launch state after a per-app switch. */
     suspend fun applyRawValues(values: Map<Int, Int>, appliedDisplayProfileId: String?): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val policies = resolvePolicies()
         if (policies.isEmpty()) {
@@ -363,7 +363,7 @@ class PerformanceRepository(
 
     suspend fun applySleepProfile(profileId: String): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val state = observeState().first()
         if (state.policies.isEmpty()) {
@@ -387,7 +387,7 @@ class PerformanceRepository(
 
     suspend fun restorePreSleepState(): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val policies = detector.detectPolicies()
         if (policies.isEmpty()) {
@@ -422,7 +422,7 @@ class PerformanceRepository(
 
     suspend fun applyPersistedLastValuesOnBoot(): Result<ApplyOutcome> {
         if (!rootCommandRunner.isAvailable) {
-            return Result.failure(IllegalStateException("PServer not available"))
+            return Result.failure(IllegalStateException("Root access not available"))
         }
         val policies = detector.detectPolicies()
         if (policies.isEmpty()) {

--- a/app/src/main/java/com/kei/pulse/root/RootCommandRunner.kt
+++ b/app/src/main/java/com/kei/pulse/root/RootCommandRunner.kt
@@ -7,20 +7,20 @@ import kotlinx.coroutines.withContext
 
 class RootCommandRunner(
     private val context: Context,
-    private val rootExec: RootExec = RootExec(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     val isAvailable: Boolean
-        get() = rootExec.pServerAvailable
+        get() = RootSupport.isAvailable
 
-    suspend fun executeScript(script: String): Result<String?> = withContext(dispatcher) {
-        runCatching {
-            RootSupport.runGeneratedScript(
-                context = context,
-                scriptName = "apply-frequencies.sh",
-                scriptContents = script,
-            )
+    suspend fun executeScript(script: String): Result<String?> =
+        withContext(dispatcher) {
+            runCatching {
+                RootSupport.runGeneratedScript(
+                    context = context,
+                    scriptName = "apply-frequencies.sh",
+                    scriptContents = script,
+                )
+            }
         }
-    }
 }

--- a/app/src/main/java/com/kei/pulse/root/RootExec.kt
+++ b/app/src/main/java/com/kei/pulse/root/RootExec.kt
@@ -4,32 +4,72 @@ import android.annotation.SuppressLint
 import android.os.IBinder
 import android.os.Parcel
 import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
 
 @SuppressLint("DiscouragedPrivateApi", "PrivateApi")
 class RootExec {
 
-    private val binder: IBinder?
-    var pServerAvailable: Boolean = false
-        private set
+    private val binder: IBinder? = findPServerBinder()
 
-    init {
-        binder = runCatching {
-            val serviceManager = Class.forName("android.os.ServiceManager")
-            val getService = serviceManager.getDeclaredMethod("getService", String::class.java)
-            val rawBinder = getService.invoke(serviceManager, "PServerBinder") as IBinder
-            pServerAvailable = true
-            rawBinder
-        }.getOrDefault(null)
-    }
+    val pServerAvailable: Boolean
+        get() = binder != null
+
+    val suAvailable: Boolean = checkSuAvailable()
 
     fun executeAsRoot(cmd: String): Result<String?> {
-        if (binder == null) return Result.failure(IllegalStateException("PServer not available"))
+        return when {
+            // Personal/root build: prefer Magisk or KernelSU when available.
+            suAvailable -> executeWithSu(cmd)
+
+            // Stock AYN firmware fallback.
+            binder != null -> executeWithPServer(cmd)
+
+            else -> Result.failure(
+                IllegalStateException(
+                    "Neither root access nor PServer is available",
+                ),
+            )
+        }
+    }
+
+    private fun findPServerBinder(): IBinder? {
+        return runCatching {
+            val serviceManager = Class.forName("android.os.ServiceManager")
+            val getService = serviceManager.getDeclaredMethod(
+                "getService",
+                String::class.java,
+            )
+
+            getService.invoke(
+                serviceManager,
+                "PServerBinder",
+            ) as? IBinder
+        }.getOrNull()
+    }
+
+    private fun executeWithPServer(cmd: String): Result<String?> {
+        val activeBinder = binder
+            ?: return Result.failure(
+                IllegalStateException("PServer is not available"),
+            )
 
         val data = Parcel.obtain()
         val reply = Parcel.obtain()
+
         return try {
             data.writeStringArray(arrayOf(cmd, "1"))
-            binder.transact(0, data, reply, 0)
+
+            val transactionSucceeded = activeBinder.transact(
+                0,
+                data,
+                reply,
+                0,
+            )
+
+            if (!transactionSucceeded) {
+                error("PServer transaction failed")
+            }
+
             Result.success(decodeReply(reply))
         } catch (throwable: Throwable) {
             Result.failure(throwable)
@@ -39,10 +79,81 @@ class RootExec {
         }
     }
 
+    private fun executeWithSu(cmd: String): Result<String?> {
+        return runCatching {
+            val process = ProcessBuilder(
+                "su",
+                "-c",
+                cmd,
+            )
+                .redirectErrorStream(true)
+                .start()
+
+            if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                process.waitFor(1, TimeUnit.SECONDS)
+                error("Root command timed out")
+            }
+
+            val output = process.inputStream
+                .bufferedReader()
+                .use { reader -> reader.readText() }
+                .trim()
+
+            val exitCode = process.exitValue()
+            if (exitCode != 0) {
+                error(
+                    "Root command failed with exit code $exitCode" +
+                        output.takeIf { it.isNotEmpty() }
+                            ?.let { ": $it" }
+                            .orEmpty(),
+                )
+            }
+
+            output.ifEmpty { null }
+        }
+    }
+
+    private fun checkSuAvailable(): Boolean {
+        return runCatching {
+            val process = ProcessBuilder(
+                "su",
+                "-c",
+                "id",
+            )
+                .redirectErrorStream(true)
+                .start()
+
+            if (!process.waitFor(SU_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                process.waitFor(1, TimeUnit.SECONDS)
+                return@runCatching false
+            }
+
+            val output = process.inputStream
+                .bufferedReader()
+                .use { reader -> reader.readText() }
+
+            process.exitValue() == 0 &&
+                UID_ZERO_PATTERN.containsMatchIn(output)
+        }.getOrDefault(false)
+    }
+
     private fun decodeReply(reply: Parcel): String? {
         return reply.createByteArray()
             ?.toString(Charset.defaultCharset())
             ?.trim()
-            ?.let { value -> if (value == "null") null else value }
+            ?.let { value ->
+                value.takeUnless { it == "null" }
+            }
+    }
+
+    private companion object {
+        const val COMMAND_TIMEOUT_SECONDS = 10L
+        const val SU_CHECK_TIMEOUT_SECONDS = 5L
+
+        val UID_ZERO_PATTERN = Regex(
+            pattern = """\buid=0(?:\(|\s|$)""",
+        )
     }
 }

--- a/app/src/main/java/com/kei/pulse/root/RootSupport.kt
+++ b/app/src/main/java/com/kei/pulse/root/RootSupport.kt
@@ -7,18 +7,32 @@ import kotlin.concurrent.withLock
 
 object RootSupport {
 
-    // Process-wide serialization of PServer access. The binder cannot service overlapping
-    // transacts reliably, and several callers (per-app watcher apply, telemetry poll, tile,
-    // sleep monitor) hit it concurrently. Every PServer path — cat() reads and the
-    // runGeneratedScript apply pipeline — funnels through runRootCommand, so locking here
-    // serializes all of them at command granularity. Each command is short and all callers
-    // run on Dispatchers.IO, so a blocking lock is fine. runGeneratedScript does not lock
-    // itself, so there is no re-entrancy.
-    private val pServerLock = ReentrantLock()
+    // Keep one executor for the lifetime of the app process.
+    // This avoids repeatedly probing PServer and repeatedly running "su -c id".
+    private val rootExec: RootExec by lazy {
+        RootExec()
+    }
+
+    // Serialize privileged commands across PServer and su backends.
+    //
+    // PServer cannot reliably service overlapping Binder transactions.
+    // The lock also prevents concurrent profile scripts from interleaving sysfs
+    // writes when the su backend is active.
+    private val commandLock = ReentrantLock()
+
+    val isAvailable: Boolean
+        get() = rootExec.pServerAvailable || rootExec.suAvailable
+
+    val backendName: String
+        get() = when {
+            rootExec.suAvailable -> "Root (su)"
+            rootExec.pServerAvailable -> "PServer"
+            else -> "Unavailable"
+        }
 
     fun runRootCommand(command: String): String? {
-        return pServerLock.withLock {
-            RootExec().executeAsRoot(command).getOrNull()
+        return commandLock.withLock {
+            rootExec.executeAsRoot(command).getOrNull()
         }
     }
 
@@ -28,16 +42,22 @@ object RootSupport {
         scriptContents: String,
     ): String? {
         val scriptDir = File(context.filesDir, "root-scripts")
-        if (!scriptDir.exists()) {
-            scriptDir.mkdirs()
+
+        if (!scriptDir.exists() && !scriptDir.mkdirs()) {
+            return null
         }
 
         val scriptFile = File(scriptDir, scriptName)
+
         scriptFile.writeText(scriptContents)
         scriptFile.setReadable(true, false)
         scriptFile.setExecutable(true, false)
 
-        val command = "sh ${scriptFile.absolutePath}"
-        return runRootCommand(command)
+        val escapedPath = shellQuote(scriptFile.absolutePath)
+        return runRootCommand("sh $escapedPath")
+    }
+
+    private fun shellQuote(value: String): String {
+        return "'" + value.replace("'", "'\\''") + "'"
     }
 }

--- a/app/src/main/java/com/kei/pulse/ui/PerAppScreen.kt
+++ b/app/src/main/java/com/kei/pulse/ui/PerAppScreen.kt
@@ -359,7 +359,8 @@ private fun PerAppConfigDialog(
                         }
                 }
 
-                // AutoTDP forces the Smart fan itself, so the fan picker is hidden for it.
+                // AutoTDP uses the global fan choice; keep the per-app fan picker hidden until
+                // the service layer explicitly supports per-app fan overrides during AutoTDP.
                 if (!PerAppConfig.isAuto(profileBinding)) {
                     DialogGroupLabel("FAN (ODIN)")
                     FlowRow(
@@ -420,7 +421,7 @@ private fun PerAppConfigDialog(
                 }
 
                 Text(
-                    text = "Applied when this app comes to the foreground; the previous state is restored when it leaves. \"Default\" leaves that control alone. AutoTDP pins the panel to max refresh and trims the CPU then GPU to hold your FPS target at the lowest power (forces Smart fan); \"Default\" target uses the global default, \"Max\" runs uncapped. Custom applies your saved Custom setup — for frequencies unique to this app, save a profile on the main screen and bind it here.",
+                    text = "Applied when this app comes to the foreground; the previous state is restored when it leaves. \"Default\" leaves that control alone. AutoTDP pins the panel to max refresh and trims the CPU then GPU to hold your FPS target at the lowest power; pair it with the global Custom fan on the main screen. \"Default\" target uses the global default, \"Max\" runs uncapped. Custom applies your saved Custom setup — for frequencies unique to this app, save a profile on the main screen and bind it here.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/kei/pulse/ui/PulseControlModules.kt
+++ b/app/src/main/java/com/kei/pulse/ui/PulseControlModules.kt
@@ -958,7 +958,7 @@ private fun wattLabel(w: Float): String = "%.1f".format(w).removeSuffix(".0")
 
 /**
  * AutoTDP master toggle. When on, PULSE dynamically trims the CPU first, then GPU, to hold each
- * foreground game's refresh-rate FPS (Smart fan, refresh rate untouched). It becomes the default
+ * foreground game's refresh-rate FPS while Custom fan can keep running. It becomes the default
  * for any game without its own per-app binding, so the manual tier/clock controls are locked.
  */
 @Composable
@@ -1008,12 +1008,14 @@ fun AutoTdpModule(
             Text(
                 text = if (enabled) {
                     "Automatically tunes the CPU and GPU clocks on the fly, aiming to hold each app's " +
-                        "frame rate at the lowest power, with the Smart fan curve enabled. The tier and " +
-                        "manual controls below are locked while AutoTDP is on. Per-app bindings still take " +
+                        "frame rate at the lowest power. Pair it with Custom fan below to keep your tuned " +
+                        "fan curve running while AutoTDP handles clocks. The tier and manual controls are " +
+                        "locked while AutoTDP is on. Per-app bindings still take " +
                         "priority, and a hand-tuned manual profile may still perform better in some games."
                 } else {
                     "Automatically tunes the CPU and GPU clocks on the fly to hold your FPS target at the " +
-                        "lowest power — games, emulators and even media — with the Smart fan curve and the " +
+                        "lowest power — games, emulators and even media. Custom fan remains available, " +
+                        "and the " +
                         "panel pinned to max refresh. Runs on any app except PULSE and the home screen; " +
                         "per-app bindings take priority."
                 },

--- a/app/src/main/java/com/kei/pulse/ui/TunerScreen.kt
+++ b/app/src/main/java/com/kei/pulse/ui/TunerScreen.kt
@@ -173,7 +173,7 @@ fun MainTunerScreen(
                 LoadingClustersCard()
             } else if (!state.isPServerAvailable) {
                 Text(
-                    text = "Your device is not compatible with this app",
+                    text = "Root access is not available on this device",
                     style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                     fontWeight = FontWeight.SemiBold,
@@ -211,10 +211,10 @@ fun MainTunerScreen(
 
                 CurrentFrequenciesCard(state = state)
 
-                // AutoTDP manages the fan + governor + clocks itself, so only the refresh rate stays
-                // adjustable while it's on.
+                // AutoTDP manages governor + clocks, but the fan remains user-configurable so
+                // Custom fan curves can be paired with AutoTDP.
+                FanModule(currentMode = fanMode, onSelect = onSelectFanMode, editor = fanCurveEditor)
                 if (!autoTdpEnabled) {
-                    FanModule(currentMode = fanMode, onSelect = onSelectFanMode, editor = fanCurveEditor)
                     GovernorModule(current = governor, onSelect = onSelectGovernor)
                 }
 
@@ -579,7 +579,7 @@ private fun PServerStatusChip(isLinked: Boolean) {
                     .background(color, CircleShape),
             )
             Text(
-                text = if (isLinked) "PSERVER · LINKED · NO-ROOT" else "PSERVER UNAVAILABLE",
+                text = if (isLinked) "ROOT ACCESS · READY" else "ROOT ACCESS UNAVAILABLE",
                 style = MaterialTheme.typography.labelSmall,
                 color = color,
             )


### PR DESCRIPTION
## Summary

This PR introduces two improvements:

1. Adds optional `su` command execution support for rooted devices while preserving the existing `PServerBinder` backend.
2. Keeps custom fan controls visible while AutoTDP is enabled, addressing the behavior reported in #1.

## Changes

### Optional `su` backend

* Detects whether `su` access is available.
* Uses `su -c` as the privileged command backend on rooted devices.
* Falls back to the existing `PServerBinder` backend when `su` is unavailable.
* Reuses a single command executor instead of repeatedly creating backend instances.
* Serializes privileged command execution to prevent sysfs writes from interleaving.
* Adds command timeout handling and checks the result of Binder transactions.

The existing rootless PServer workflow remains supported and has not been removed.

### AutoTDP fan controls

* Keeps the fan control module visible while AutoTDP is active.
* Allows users to view and adjust the active custom fan configuration without first disabling AutoTDP.
* Continues hiding other manual performance controls that conflict with AutoTDP.

## Motivation

Pulse currently relies on the vendor-provided `PServerBinder` service for privileged operations. Supporting `su` provides an additional execution backend for rooted devices and improves compatibility with systems where PServer is unavailable.

The fan-control change resolves a confusing UI state in which a previously selected custom fan profile continues running under AutoTDP, while its controls are hidden.

## Compatibility

* Non-rooted AYN devices continue using `PServerBinder`.
* Rooted devices use the `su` backend when access is available.
* The original PServer execution path remains available as a fallback.
* No existing PServer functionality is intentionally removed.
* The UI change is limited to fan-control visibility while AutoTDP is active.

## Testing

Tested successfully on a rooted AYN Odin 3:

* Debug APK builds and installs successfully.
* Root authorization and `su -c` command execution work correctly.
* Performance profiles and privileged sysfs writes apply successfully.
* AutoTDP continues to function normally.
* Custom fan controls remain visible and functional while AutoTDP is enabled.
* Foreground-app profile switching works as expected.
* Sleep and resume behavior remains functional.
* Existing profile restoration behavior continues to work.

The existing PServer code path has also been preserved for non-rooted devices.
