### PR TITLE
Honor per-app fan precedence during AutoTDP

### DIFF
--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -1450,7 +1450,8 @@ class ForegroundAppMonitorService : Service() {
         autoTdpTick = 0
         // Fan: force vendor Smart UNLESS the user runs the Custom fan — then reassertManagedFan keeps driving
         // their (quieter) closed-loop Custom fan during AutoTDP instead.
-        if (settings.managedFanMode != FanController.CUSTOM) fanController.setMode(FanController.SMART)
+        val desiredFanMode = FanArbiter.desiredMode(config?.fanMode, settings.managedFanMode)
+        if (desiredFanMode != FanController.CUSTOM) fanController.setMode(FanController.SMART)
         GovernorController.OPTIONS.firstOrNull { it.label == "Balanced" }
             ?.let { governorController.setGovernor(policies, it) }
         overlayProfileLabel = "AutoTDP"

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -1450,8 +1450,15 @@ class ForegroundAppMonitorService : Service() {
         autoTdpTick = 0
         // Fan: force vendor Smart UNLESS the user runs the Custom fan — then reassertManagedFan keeps driving
         // their (quieter) closed-loop Custom fan during AutoTDP instead.
-        val desiredFanMode = FanArbiter.desiredMode(config?.fanMode, settings.managedFanMode)
-        if (desiredFanMode != FanController.CUSTOM) fanController.setMode(FanController.SMART)
+        if (
+            !FanArbiter.usesCustomFanDuringAutoTdp(
+                boundFanMode = config?.fanMode,
+                managedFanMode = settings.managedFanMode,
+                customFanSupported = isCustomFanSupported(),
+            )
+        ) {
+            fanController.setMode(FanController.SMART)
+        }
         GovernorController.OPTIONS.firstOrNull { it.label == "Balanced" }
             ?.let { governorController.setGovernor(policies, it) }
         overlayProfileLabel = "AutoTDP"

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -1451,7 +1451,7 @@ class ForegroundAppMonitorService : Service() {
         // Fan: force vendor Smart UNLESS the user runs the Custom fan — then reassertManagedFan keeps driving
         // their (quieter) closed-loop Custom fan during AutoTDP instead.
         if (
-            !FanArbiter.usesCustomFanDuringAutoTdp(
+            FanArbiter.shouldForceSmartDuringAutoTdp(
                 boundFanMode = config?.fanMode,
                 managedFanMode = settings.managedFanMode,
                 customFanSupported = isCustomFanSupported(),

--- a/app/src/main/java/com/kei/pulse/model/FanArbiter.kt
+++ b/app/src/main/java/com/kei/pulse/model/FanArbiter.kt
@@ -36,6 +36,14 @@ object FanArbiter {
     fun desiredMode(boundFanMode: Int?, managedFanMode: Int?): Int? =
         boundFanMode ?: managedFanMode
 
+    /** Whether AutoTDP should run the Custom loop instead of forcing the safe vendor Smart mode. */
+    fun usesCustomFanDuringAutoTdp(
+        boundFanMode: Int?,
+        managedFanMode: Int?,
+        customFanSupported: Boolean,
+    ): Boolean =
+        desiredMode(boundFanMode, managedFanMode) == FanController.CUSTOM && customFanSupported
+
     /**
      * @param autoTdpActive an AutoTDP session owns the clocks (and set vendor Smart at session start);
      *   the fan only cascades the user's Custom loop, never other managed modes.
@@ -56,17 +64,17 @@ object FanArbiter {
         releaseMode: Int,
         readLiveMode: () -> Int?,
     ): FanAction {
-        val desired = desiredMode(boundFanMode, managedFanMode)
         // AutoTDP owns the fan: cascade the user's Custom loop if chosen + supported, else stand down
         // (startAutoTdp already forced vendor Smart for non-Custom).
         if (autoTdpActive) {
-            return if (desired == FanController.CUSTOM && customFanSupported) {
+            return if (usesCustomFanDuringAutoTdp(boundFanMode, managedFanMode, customFanSupported)) {
                 FanAction.RunCustomLoop
             } else {
                 FanAction.None
             }
         }
         // The fan PULSE wants: a foreground app's per-app fan takes priority, else the global Fan-card mode.
+        val desired = desiredMode(boundFanMode, managedFanMode)
         if (desired == null) {
             // Unmanaged. On the release EDGE (not latched), normalize the fan to [releaseMode] if it was left
             // somewhere else (a managed vendor mode, or Custom's manual passthrough). Once latched, PULSE is

--- a/app/src/main/java/com/kei/pulse/model/FanArbiter.kt
+++ b/app/src/main/java/com/kei/pulse/model/FanArbiter.kt
@@ -36,13 +36,13 @@ object FanArbiter {
     fun desiredMode(boundFanMode: Int?, managedFanMode: Int?): Int? =
         boundFanMode ?: managedFanMode
 
-    /** Whether AutoTDP should run the Custom loop instead of forcing the safe vendor Smart mode. */
-    fun usesCustomFanDuringAutoTdp(
+    /** Whether AutoTDP should force the safe vendor Smart mode instead of running the Custom loop. */
+    fun shouldForceSmartDuringAutoTdp(
         boundFanMode: Int?,
         managedFanMode: Int?,
         customFanSupported: Boolean,
     ): Boolean =
-        desiredMode(boundFanMode, managedFanMode) == FanController.CUSTOM && customFanSupported
+        desiredMode(boundFanMode, managedFanMode) != FanController.CUSTOM || !customFanSupported
 
     /**
      * @param autoTdpActive an AutoTDP session owns the clocks (and set vendor Smart at session start);
@@ -67,10 +67,10 @@ object FanArbiter {
         // AutoTDP owns the fan: cascade the user's Custom loop if chosen + supported, else stand down
         // (startAutoTdp already forced vendor Smart for non-Custom).
         if (autoTdpActive) {
-            return if (usesCustomFanDuringAutoTdp(boundFanMode, managedFanMode, customFanSupported)) {
-                FanAction.RunCustomLoop
-            } else {
+            return if (shouldForceSmartDuringAutoTdp(boundFanMode, managedFanMode, customFanSupported)) {
                 FanAction.None
+            } else {
+                FanAction.RunCustomLoop
             }
         }
         // The fan PULSE wants: a foreground app's per-app fan takes priority, else the global Fan-card mode.

--- a/app/src/main/java/com/kei/pulse/model/FanArbiter.kt
+++ b/app/src/main/java/com/kei/pulse/model/FanArbiter.kt
@@ -32,6 +32,10 @@ sealed interface FanAction {
  */
 object FanArbiter {
 
+    /** The foreground app's fan override wins over the global Fan-card setting. */
+    fun desiredMode(boundFanMode: Int?, managedFanMode: Int?): Int? =
+        boundFanMode ?: managedFanMode
+
     /**
      * @param autoTdpActive an AutoTDP session owns the clocks (and set vendor Smart at session start);
      *   the fan only cascades the user's Custom loop, never other managed modes.
@@ -52,17 +56,17 @@ object FanArbiter {
         releaseMode: Int,
         readLiveMode: () -> Int?,
     ): FanAction {
+        val desired = desiredMode(boundFanMode, managedFanMode)
         // AutoTDP owns the fan: cascade the user's Custom loop if chosen + supported, else stand down
         // (startAutoTdp already forced vendor Smart for non-Custom).
         if (autoTdpActive) {
-            return if (managedFanMode == FanController.CUSTOM && customFanSupported) {
+            return if (desired == FanController.CUSTOM && customFanSupported) {
                 FanAction.RunCustomLoop
             } else {
                 FanAction.None
             }
         }
         // The fan PULSE wants: a foreground app's per-app fan takes priority, else the global Fan-card mode.
-        val desired = boundFanMode ?: managedFanMode
         if (desired == null) {
             // Unmanaged. On the release EDGE (not latched), normalize the fan to [releaseMode] if it was left
             // somewhere else (a managed vendor mode, or Custom's manual passthrough). Once latched, PULSE is

--- a/app/src/test/java/com/kei/pulse/model/FanArbiterTest.kt
+++ b/app/src/test/java/com/kei/pulse/model/FanArbiterTest.kt
@@ -67,6 +67,26 @@ class FanArbiterTest {
     }
 
     @Test
+    fun `autotdp falls back to vendor smart when the selected custom fan is unsupported`() {
+        assertEquals(
+            false,
+            FanArbiter.usesCustomFanDuringAutoTdp(
+                boundFanMode = FanController.CUSTOM,
+                managedFanMode = FanController.SPORT,
+                customFanSupported = false,
+            ),
+        )
+        assertEquals(
+            true,
+            FanArbiter.usesCustomFanDuringAutoTdp(
+                boundFanMode = FanController.CUSTOM,
+                managedFanMode = FanController.SPORT,
+                customFanSupported = true,
+            ),
+        )
+    }
+
+    @Test
     fun `autotdp with custom unsupported stands down, no mode read`() {
         assertEquals(
             FanAction.None,

--- a/app/src/test/java/com/kei/pulse/model/FanArbiterTest.kt
+++ b/app/src/test/java/com/kei/pulse/model/FanArbiterTest.kt
@@ -41,6 +41,32 @@ class FanArbiterTest {
     }
 
     @Test
+    fun `autotdp honors a per-app custom fan over the global mode`() {
+        assertEquals(
+            FanAction.RunCustomLoop,
+            decide(
+                autoTdpActive = true,
+                boundFanMode = FanController.CUSTOM,
+                managedFanMode = FanController.SPORT,
+                readLiveMode = mustNotRead,
+            ),
+        )
+    }
+
+    @Test
+    fun `autotdp does not let global custom override a per-app vendor mode`() {
+        assertEquals(
+            FanAction.None,
+            decide(
+                autoTdpActive = true,
+                boundFanMode = FanController.SPORT,
+                managedFanMode = FanController.CUSTOM,
+                readLiveMode = mustNotRead,
+            ),
+        )
+    }
+
+    @Test
     fun `autotdp with custom unsupported stands down, no mode read`() {
         assertEquals(
             FanAction.None,

--- a/app/src/test/java/com/kei/pulse/model/FanArbiterTest.kt
+++ b/app/src/test/java/com/kei/pulse/model/FanArbiterTest.kt
@@ -69,16 +69,16 @@ class FanArbiterTest {
     @Test
     fun `autotdp falls back to vendor smart when the selected custom fan is unsupported`() {
         assertEquals(
-            false,
-            FanArbiter.usesCustomFanDuringAutoTdp(
+            true,
+            FanArbiter.shouldForceSmartDuringAutoTdp(
                 boundFanMode = FanController.CUSTOM,
                 managedFanMode = FanController.SPORT,
                 customFanSupported = false,
             ),
         )
         assertEquals(
-            true,
-            FanArbiter.usesCustomFanDuringAutoTdp(
+            false,
+            FanArbiter.shouldForceSmartDuringAutoTdp(
                 boundFanMode = FanController.CUSTOM,
                 managedFanMode = FanController.SPORT,
                 customFanSupported = true,


### PR DESCRIPTION
## Problem

AutoTDP startup considered only the global fan setting while ongoing arbitration used per-app-over-global precedence. Custom fan selection also did not account for runtime support during startup, so an unsupported Custom mode could skip the safe vendor Smart fallback.

## Root cause

Startup and ongoing arbitration independently decided whether Custom owned the fan, and only the ongoing path received the Custom-support capability.

## Changes

- centralize per-app-over-global desired fan resolution
- centralize the supported-Custom decision shared by AutoTDP startup and ongoing arbitration
- force vendor Smart at startup whenever the selected Custom loop is unavailable
- preserve the no-extra-read contract for AutoTDP fan decisions
- add regression tests for both precedence directions and unsupported-Custom fallback

## User impact

Per-app fan choices consistently win during AutoTDP, while devices that cannot run the selected Custom loop safely fall back to vendor Smart instead of retaining a stale fan mode.

## Validation

- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- hardware validation has not been performed by the contributor

## AI assistance disclosure

This change was created with assistance from ChatGPT using the GPT-5 model. The contributor reviewed the resulting code and ran the validation listed above.