### PR TITLE
Show per-app AutoTDP overrides in notifications

### DIFF
--- a/app/src/main/java/com/kei/pulse/MainActivity.kt
+++ b/app/src/main/java/com/kei/pulse/MainActivity.kt
@@ -115,6 +115,8 @@ class MainActivity : ComponentActivity() {
                     val perAppEnabled = viewModel.perAppEnabled.collectAsStateWithLifecycle().value
                     val perAppConfigs = viewModel.perAppConfigs.collectAsStateWithLifecycle().value
                     val perAppSwitchNotices = viewModel.perAppSwitchNotices.collectAsStateWithLifecycle().value
+                    val perAppSwitchNoticeDetails =
+                        viewModel.perAppSwitchNoticeDetails.collectAsStateWithLifecycle().value
 
                     // Existing per-app bindings must engage on launch even if the master toggle was never
                     // flipped — the watcher self-stops if nothing needs it. (Per-app comes first.)
@@ -193,6 +195,8 @@ class MainActivity : ComponentActivity() {
                             onOpenPerApps = { showPerApps = true },
                             perAppSwitchNotices = perAppSwitchNotices,
                             onPerAppSwitchNoticesChange = viewModel::setPerAppSwitchNotices,
+                            perAppSwitchNoticeDetails = perAppSwitchNoticeDetails,
+                            onPerAppSwitchNoticeDetailsChange = viewModel::setPerAppSwitchNoticeDetails,
                             overlayEnabled = settings.overlayEnabled,
                             overlayPreset = settings.overlayPreset,
                             overlayElements = settings.overlayElements,

--- a/app/src/main/java/com/kei/pulse/appwatch/AutoTdpNotice.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/AutoTdpNotice.kt
@@ -1,0 +1,53 @@
+package com.kei.pulse.appwatch
+
+import com.kei.pulse.model.AppSettings
+import com.kei.pulse.model.PerAppConfig
+
+/** Compact and expanded notification text for an applied per-app AutoTDP profile. */
+data class AutoTdpNoticeText(
+    val compact: String,
+    val expanded: String,
+)
+
+/** Builds the per-app AutoTDP switch notice, calling out only values that override global defaults. */
+object AutoTdpNotice {
+    fun text(
+        appName: String,
+        config: PerAppConfig,
+        global: AppSettings,
+        includeOverrides: Boolean = true,
+    ): AutoTdpNoticeText {
+        val overrides = mutableListOf<Override>()
+
+        if (includeOverrides) {
+            config.fpsTarget
+                ?.takeIf { it != global.autoTdpFpsTarget }
+                ?.let { overrides += Override("FPS target", PerAppConfig.fpsTargetLabel(it)) }
+            config.aggressivePark
+                ?.takeIf { it != global.autoTdpAggressivePark }
+                ?.let { overrides += Override("Aggressive park", if (it) "On" else "Off") }
+            config.bias
+                ?.takeIf { it != global.autoTdpBias }
+                ?.let { overrides += Override("Efficiency", it.label) }
+        }
+
+        val heading = "$appName: AutoTDP"
+        return AutoTdpNoticeText(
+            // The system owns the collapsed notification height and may ellipsize a long content line.
+            // Keep that template concise; the complete detail lives in the wrapping BigTextStyle below.
+            compact = heading,
+            // Let BigTextStyle keep this on one line when it fits. The ordinary spaces before each diamond
+            // are safe wrap points; everything from the diamond through its key/value uses non-breaking
+            // spaces, so Android can reflow for the real screen width without splitting a setting.
+            expanded = heading + overrides.joinToString(separator = "") {
+                "  ◆\u00a0${keepTogether(it.display())}"
+            },
+        )
+    }
+
+    private fun keepTogether(setting: String): String = setting.replace(' ', '\u00a0')
+
+    private data class Override(val key: String, val value: String) {
+        fun display(): String = "$key › $value"
+    }
+}

--- a/app/src/main/java/com/kei/pulse/appwatch/AutoTdpNotice.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/AutoTdpNotice.kt
@@ -3,11 +3,30 @@ package com.kei.pulse.appwatch
 import com.kei.pulse.model.AppSettings
 import com.kei.pulse.model.PerAppConfig
 
-/** Compact and expanded notification text for an applied per-app AutoTDP profile. */
-data class AutoTdpNoticeText(
-    val compact: String,
-    val expanded: String,
+/** Keeps every key/value setting together while Android wraps between complete setting groups. */
+internal const val SETTING_NON_BREAKING_SPACE = '\u00a0'
+
+data class AutoTdpNoticeSetting(
+    val key: String,
+    val value: String,
 )
+
+/** Structured content for an applied per-app AutoTDP notification. */
+data class AutoTdpNoticeText(
+    val appName: String,
+    val settings: List<AutoTdpNoticeSetting>,
+) {
+    val compact: String
+        get() = "$appName: AutoTDP"
+
+    val expanded: String
+        get() = compact + settings.joinToString(separator = "") {
+            "  ◆$SETTING_NON_BREAKING_SPACE${it.displayKeepingTogether()}"
+        }
+
+    private fun AutoTdpNoticeSetting.displayKeepingTogether(): String =
+        "$key › $value".replace(' ', SETTING_NON_BREAKING_SPACE)
+}
 
 /** Builds the per-app AutoTDP switch notice, calling out only values that override global defaults. */
 object AutoTdpNotice {
@@ -17,37 +36,22 @@ object AutoTdpNotice {
         global: AppSettings,
         includeOverrides: Boolean = true,
     ): AutoTdpNoticeText {
-        val overrides = mutableListOf<Override>()
+        val overrides = mutableListOf<AutoTdpNoticeSetting>()
 
         if (includeOverrides) {
             config.fpsTarget
                 ?.takeIf { it != global.autoTdpFpsTarget }
-                ?.let { overrides += Override("FPS target", PerAppConfig.fpsTargetLabel(it)) }
+                ?.let { overrides += AutoTdpNoticeSetting("FPS target", PerAppConfig.fpsTargetLabel(it)) }
             config.aggressivePark
                 ?.takeIf { it != global.autoTdpAggressivePark }
-                ?.let { overrides += Override("Aggressive park", if (it) "On" else "Off") }
+                ?.let { overrides += AutoTdpNoticeSetting("Aggressive park", if (it) "On" else "Off") }
             config.bias
                 ?.takeIf { it != global.autoTdpBias }
-                ?.let { overrides += Override("Efficiency", it.label) }
+                ?.let { overrides += AutoTdpNoticeSetting("Efficiency", it.label) }
         }
 
-        val heading = "$appName: AutoTDP"
-        return AutoTdpNoticeText(
-            // The system owns the collapsed notification height and may ellipsize a long content line.
-            // Keep that template concise; the complete detail lives in the wrapping BigTextStyle below.
-            compact = heading,
-            // Let BigTextStyle keep this on one line when it fits. The ordinary spaces before each diamond
-            // are safe wrap points; everything from the diamond through its key/value uses non-breaking
-            // spaces, so Android can reflow for the real screen width without splitting a setting.
-            expanded = heading + overrides.joinToString(separator = "") {
-                "  ◆\u00a0${keepTogether(it.display())}"
-            },
-        )
-    }
-
-    private fun keepTogether(setting: String): String = setting.replace(' ', '\u00a0')
-
-    private data class Override(val key: String, val value: String) {
-        fun display(): String = "$key › $value"
+        // The compact template stays concise. BigTextStyle renders [settings] on one line when possible and
+        // wraps only at the ordinary spaces before each diamond; each setting itself uses non-breaking spaces.
+        return AutoTdpNoticeText(appName, overrides)
     }
 }

--- a/app/src/main/java/com/kei/pulse/appwatch/AutoTdpNotice.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/AutoTdpNotice.kt
@@ -5,6 +5,12 @@ import com.kei.pulse.model.PerAppConfig
 
 /** Keeps every key/value setting together while Android wraps between complete setting groups. */
 internal const val SETTING_NON_BREAKING_SPACE = '\u00a0'
+internal const val SETTING_BREAKABLE_SPACE = ' '
+internal const val SETTING_GROUP_WRAP_OPPORTUNITY = "  "
+internal const val SETTING_GROUP_MARKER = '◆'
+internal const val SETTING_KEY_VALUE_SEPARATOR = '›'
+internal const val NOTICE_HEADING_SEPARATOR = ": "
+internal const val AUTOTDP_NOTICE_LABEL = "AutoTDP"
 
 data class AutoTdpNoticeSetting(
     val key: String,
@@ -17,15 +23,24 @@ data class AutoTdpNoticeText(
     val settings: List<AutoTdpNoticeSetting>,
 ) {
     val compact: String
-        get() = "$appName: AutoTDP"
+        get() = "$appName$NOTICE_HEADING_SEPARATOR$AUTOTDP_NOTICE_LABEL"
 
     val expanded: String
         get() = compact + settings.joinToString(separator = "") {
-            "  ◆$SETTING_NON_BREAKING_SPACE${it.displayKeepingTogether()}"
+            "$SETTING_GROUP_WRAP_OPPORTUNITY$SETTING_GROUP_MARKER" +
+                "$SETTING_NON_BREAKING_SPACE${it.displayKeepingTogether()}"
         }
 
     private fun AutoTdpNoticeSetting.displayKeepingTogether(): String =
-        "$key › $value".replace(' ', SETTING_NON_BREAKING_SPACE)
+        key.asNonBreakingSettingText() +
+            SETTING_NON_BREAKING_SPACE +
+            SETTING_KEY_VALUE_SEPARATOR +
+            SETTING_NON_BREAKING_SPACE +
+            value.asNonBreakingSettingText()
+
+    /** A future multi-word key or value must remain part of its indivisible setting group. */
+    private fun String.asNonBreakingSettingText(): String =
+        replace(SETTING_BREAKABLE_SPACE, SETTING_NON_BREAKING_SPACE)
 }
 
 /** Builds the per-app AutoTDP switch notice, calling out only values that override global defaults. */

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -1981,9 +1981,10 @@ class ForegroundAppMonitorService : Service() {
         val styled = SpannableStringBuilder()
         val mutedAccent = (accentColor and 0x00ffffff) or (0xa0 shl 24)
 
-        styled.append("${notice.appName}: ")
+        styled.append(notice.appName)
+        styled.append(NOTICE_HEADING_SEPARATOR)
         val autoTdpStart = styled.length
-        styled.append("AutoTDP")
+        styled.append(AUTOTDP_NOTICE_LABEL)
         styled.setSpan(
             StyleSpan(Typeface.BOLD),
             autoTdpStart,
@@ -1992,29 +1993,16 @@ class ForegroundAppMonitorService : Service() {
         )
 
         if (expanded) notice.settings.forEach { setting ->
-            styled.append("  ") // the safe wrap point between complete setting groups
-            val diamondStart = styled.length
-            styled.append('◆')
-            styled.setSpan(
-                ForegroundColorSpan(mutedAccent),
-                diamondStart,
-                styled.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
-            )
-            styled.append(SETTING_NON_BREAKING_SPACE)
-            styled.append(setting.key.replace(' ', SETTING_NON_BREAKING_SPACE))
-            styled.append(SETTING_NON_BREAKING_SPACE)
-            val arrowStart = styled.length
-            styled.append('›')
-            styled.setSpan(
-                ForegroundColorSpan(mutedAccent),
-                arrowStart,
-                styled.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
-            )
-            styled.append(SETTING_NON_BREAKING_SPACE)
+            styled.append(SETTING_GROUP_WRAP_OPPORTUNITY)
+            styled.appendMutedToken(SETTING_GROUP_MARKER, mutedAccent)
+            styled.appendNonBreakingGap()
+            styled.appendSettingText(setting.key)
+            styled.appendNonBreakingGap()
+            styled.appendMutedToken(SETTING_KEY_VALUE_SEPARATOR, mutedAccent)
+            styled.appendNonBreakingGap()
             val valueStart = styled.length
-            styled.append(setting.value.replace(' ', SETTING_NON_BREAKING_SPACE))
+            // Values are currently single words/numbers; normalization keeps future multi-word values intact.
+            styled.appendSettingText(setting.value)
             styled.setSpan(
                 ForegroundColorSpan(accentColor),
                 valueStart,
@@ -2029,6 +2017,25 @@ class ForegroundAppMonitorService : Service() {
             )
         }
         return styled
+    }
+
+    private fun SpannableStringBuilder.appendNonBreakingGap() {
+        append(SETTING_NON_BREAKING_SPACE)
+    }
+
+    private fun SpannableStringBuilder.appendSettingText(text: String) {
+        append(text.replace(SETTING_BREAKABLE_SPACE, SETTING_NON_BREAKING_SPACE))
+    }
+
+    private fun SpannableStringBuilder.appendMutedToken(token: Char, color: Int) {
+        val start = length
+        append(token)
+        setSpan(
+            ForegroundColorSpan(color),
+            start,
+            length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -16,16 +16,14 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.Process
 import android.graphics.Typeface
-import android.graphics.Bitmap
 import android.text.Spannable
-import android.text.SpannableString
+import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.toBitmap
 import android.media.AudioManager
 import androidx.core.content.getSystemService
 import com.kei.pulse.AppContainer
@@ -1469,11 +1467,10 @@ class ForegroundAppMonitorService : Service() {
             val notice = AutoTdpNotice.text(appName, config, settings, includeOverrides)
             showToast("PULSE · ${notice.expanded}")
             updateNotification(
-                styledAutoTdpText(notice.compact, settings.accentColor),
+                styledAutoTdpText(notice, expanded = false, accentColor = settings.accentColor),
                 notice.expanded.takeIf { includeOverrides }
-                    ?.let { styledAutoTdpText(it, settings.accentColor) },
+                    ?.let { styledAutoTdpText(notice, expanded = true, accentColor = settings.accentColor) },
                 settings.accentColor,
-                loadAppIcon(pkg),
             )
         }
     }
@@ -1968,66 +1965,66 @@ class ForegroundAppMonitorService : Service() {
         text: CharSequence,
         expandedText: CharSequence? = null,
         accentColor: Int? = null,
-        largeIcon: Bitmap? = null,
     ) {
         getSystemService<NotificationManager>()?.notify(
             NOTIFICATION_ID,
-            buildNotification(text, expandedText, accentColor, largeIcon),
+            buildNotification(text, expandedText, accentColor),
         )
     }
 
-    private fun loadAppIcon(packageName: String): Bitmap? = runCatching {
-        packageManager.getApplicationIcon(packageName).toBitmap(width = 96, height = 96)
-    }.getOrNull()
-
-    /** Accent values and punctuation while leaving keys in Android's contrast-safe notification color. */
-    private fun styledAutoTdpText(text: String, accentColor: Int): CharSequence {
-        val styled = SpannableString(text)
+    /** Builds rich text directly from structured settings; keys retain Android's contrast-safe text color. */
+    private fun styledAutoTdpText(
+        notice: AutoTdpNoticeText,
+        expanded: Boolean,
+        accentColor: Int,
+    ): CharSequence {
+        val styled = SpannableStringBuilder()
         val mutedAccent = (accentColor and 0x00ffffff) or (0xa0 shl 24)
 
-        listOf('◆', '›').forEach { marker ->
-            text.forEachIndexed { index, char ->
-                if (char == marker) {
-                    styled.setSpan(
-                        ForegroundColorSpan(mutedAccent),
-                        index,
-                        index + 1,
-                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
-                    )
-                }
-            }
-        }
+        styled.append("${notice.appName}: ")
+        val autoTdpStart = styled.length
+        styled.append("AutoTDP")
+        styled.setSpan(
+            StyleSpan(Typeface.BOLD),
+            autoTdpStart,
+            styled.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
 
-        var valueStart = text.indexOf('›')
-        while (valueStart >= 0) {
-            valueStart++
-            while (valueStart < text.length && text[valueStart].isWhitespace()) valueStart++
-            val valueEnd = sequenceOf(text.indexOf('◆', valueStart), text.indexOf('\n', valueStart))
-                .filter { it >= 0 }
-                .minOrNull()
-                ?: text.length
-            if (valueStart < valueEnd) {
-                styled.setSpan(
-                    ForegroundColorSpan(accentColor),
-                    valueStart,
-                    valueEnd,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
-                )
-                styled.setSpan(
-                    StyleSpan(Typeface.BOLD),
-                    valueStart,
-                    valueEnd,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
-                )
-            }
-            valueStart = text.indexOf('›', valueEnd)
-        }
-
-        text.indexOf("AutoTDP").takeIf { it >= 0 }?.let { start ->
+        if (expanded) notice.settings.forEach { setting ->
+            styled.append("  ") // the safe wrap point between complete setting groups
+            val diamondStart = styled.length
+            styled.append('◆')
+            styled.setSpan(
+                ForegroundColorSpan(mutedAccent),
+                diamondStart,
+                styled.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+            styled.append(SETTING_NON_BREAKING_SPACE)
+            styled.append(setting.key.replace(' ', SETTING_NON_BREAKING_SPACE))
+            styled.append(SETTING_NON_BREAKING_SPACE)
+            val arrowStart = styled.length
+            styled.append('›')
+            styled.setSpan(
+                ForegroundColorSpan(mutedAccent),
+                arrowStart,
+                styled.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+            styled.append(SETTING_NON_BREAKING_SPACE)
+            val valueStart = styled.length
+            styled.append(setting.value.replace(' ', SETTING_NON_BREAKING_SPACE))
+            styled.setSpan(
+                ForegroundColorSpan(accentColor),
+                valueStart,
+                styled.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
             styled.setSpan(
                 StyleSpan(Typeface.BOLD),
-                start,
-                start + "AutoTDP".length,
+                valueStart,
+                styled.length,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
             )
         }
@@ -2050,7 +2047,6 @@ class ForegroundAppMonitorService : Service() {
         contentText: CharSequence = "Watching for configured apps to apply their profiles.",
         expandedText: CharSequence? = null,
         accentColor: Int? = null,
-        largeIcon: Bitmap? = null,
     ): android.app.Notification {
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_tile_underclock)
@@ -2058,7 +2054,6 @@ class ForegroundAppMonitorService : Service() {
             .setContentText(contentText)
             .apply {
                 accentColor?.let(::setColor)
-                largeIcon?.let(::setLargeIcon)
                 expandedText?.let {
                     setStyle(NotificationCompat.BigTextStyle().bigText(it))
                 }

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -15,10 +15,17 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.os.Process
+import android.graphics.Typeface
+import android.graphics.Bitmap
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import android.media.AudioManager
 import androidx.core.content.getSystemService
 import com.kei.pulse.AppContainer
@@ -1458,8 +1465,16 @@ class ForegroundAppMonitorService : Service() {
         // app switch.
         if (config != null && container.perAppConfigStorage.switchNotices.first()) {
             val appName = config.appLabel.takeIf { it.isNotBlank() } ?: pkg
-            showToast("PULSE · $appName: AutoTDP")
-            updateNotification("$appName: AutoTDP")
+            val includeOverrides = container.perAppConfigStorage.switchNoticeDetails.first()
+            val notice = AutoTdpNotice.text(appName, config, settings, includeOverrides)
+            showToast("PULSE · ${notice.expanded}")
+            updateNotification(
+                styledAutoTdpText(notice.compact, settings.accentColor),
+                notice.expanded.takeIf { includeOverrides }
+                    ?.let { styledAutoTdpText(it, settings.accentColor) },
+                settings.accentColor,
+                loadAppIcon(pkg),
+            )
         }
     }
 
@@ -1949,8 +1964,74 @@ class ForegroundAppMonitorService : Service() {
         }
     }
 
-    private fun updateNotification(text: String) {
-        getSystemService<NotificationManager>()?.notify(NOTIFICATION_ID, buildNotification(text))
+    private fun updateNotification(
+        text: CharSequence,
+        expandedText: CharSequence? = null,
+        accentColor: Int? = null,
+        largeIcon: Bitmap? = null,
+    ) {
+        getSystemService<NotificationManager>()?.notify(
+            NOTIFICATION_ID,
+            buildNotification(text, expandedText, accentColor, largeIcon),
+        )
+    }
+
+    private fun loadAppIcon(packageName: String): Bitmap? = runCatching {
+        packageManager.getApplicationIcon(packageName).toBitmap(width = 96, height = 96)
+    }.getOrNull()
+
+    /** Accent values and punctuation while leaving keys in Android's contrast-safe notification color. */
+    private fun styledAutoTdpText(text: String, accentColor: Int): CharSequence {
+        val styled = SpannableString(text)
+        val mutedAccent = (accentColor and 0x00ffffff) or (0xa0 shl 24)
+
+        listOf('◆', '›').forEach { marker ->
+            text.forEachIndexed { index, char ->
+                if (char == marker) {
+                    styled.setSpan(
+                        ForegroundColorSpan(mutedAccent),
+                        index,
+                        index + 1,
+                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+                    )
+                }
+            }
+        }
+
+        var valueStart = text.indexOf('›')
+        while (valueStart >= 0) {
+            valueStart++
+            while (valueStart < text.length && text[valueStart].isWhitespace()) valueStart++
+            val valueEnd = sequenceOf(text.indexOf('◆', valueStart), text.indexOf('\n', valueStart))
+                .filter { it >= 0 }
+                .minOrNull()
+                ?: text.length
+            if (valueStart < valueEnd) {
+                styled.setSpan(
+                    ForegroundColorSpan(accentColor),
+                    valueStart,
+                    valueEnd,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+                styled.setSpan(
+                    StyleSpan(Typeface.BOLD),
+                    valueStart,
+                    valueEnd,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+            }
+            valueStart = text.indexOf('›', valueEnd)
+        }
+
+        text.indexOf("AutoTDP").takeIf { it >= 0 }?.let { start ->
+            styled.setSpan(
+                StyleSpan(Typeface.BOLD),
+                start,
+                start + "AutoTDP".length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
+        return styled
     }
 
     private fun createNotificationChannel() {
@@ -1966,12 +2047,22 @@ class ForegroundAppMonitorService : Service() {
     }
 
     private fun buildNotification(
-        contentText: String = "Watching for configured apps to apply their profiles.",
-    ) =
-        NotificationCompat.Builder(this, CHANNEL_ID)
+        contentText: CharSequence = "Watching for configured apps to apply their profiles.",
+        expandedText: CharSequence? = null,
+        accentColor: Int? = null,
+        largeIcon: Bitmap? = null,
+    ): android.app.Notification {
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_tile_underclock)
             .setContentTitle("PULSE per-app profiles")
             .setContentText(contentText)
+            .apply {
+                accentColor?.let(::setColor)
+                largeIcon?.let(::setLargeIcon)
+                expandedText?.let {
+                    setStyle(NotificationCompat.BigTextStyle().bigText(it))
+                }
+            }
             .setOngoing(true)
             .setShowWhen(false)
             .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -1983,22 +2074,23 @@ class ForegroundAppMonitorService : Service() {
                     PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
                 ),
             )
-            // In-game entry point to (un)lock the overlay for repositioning — works from the
-            // notification shade, which is reachable over full-screen games.
-            .addAction(
-                NotificationCompat.Action.Builder(
-                    R.drawable.ic_tile_underclock,
-                    "Move overlay",
-                    PendingIntent.getService(
-                        this,
-                        1,
-                        Intent(this, ForegroundAppMonitorService::class.java)
-                            .setAction(ACTION_TOGGLE_OVERLAY_LOCK),
-                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-                    ),
-                ).build(),
-            )
-            .build()
+        // In-game entry point to (un)lock the overlay for repositioning — works from the
+        // notification shade, which is reachable over full-screen games.
+        builder.addAction(
+            NotificationCompat.Action.Builder(
+                R.drawable.ic_tile_underclock,
+                "Move overlay",
+                PendingIntent.getService(
+                    this,
+                    1,
+                    Intent(this, ForegroundAppMonitorService::class.java)
+                        .setAction(ACTION_TOGGLE_OVERLAY_LOCK),
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                ),
+            ).build(),
+        )
+        return builder.build()
+    }
 
     companion object {
         private const val CHANNEL_ID = "per_app_profile_monitoring"

--- a/app/src/main/java/com/kei/pulse/data/PerAppConfigStorage.kt
+++ b/app/src/main/java/com/kei/pulse/data/PerAppConfigStorage.kt
@@ -21,6 +21,7 @@ class PerAppConfigStorage(private val context: Context) {
     private val configsKey = stringPreferencesKey("per_app_configs")
     private val restoreKey = stringPreferencesKey("per_app_restore")
     private val switchNoticesKey = booleanPreferencesKey("per_app_switch_notices")
+    private val switchNoticeDetailsKey = booleanPreferencesKey("per_app_switch_notice_details")
     private val batteryWhKey = floatPreferencesKey("battery_capacity_wh")
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -65,6 +66,17 @@ class PerAppConfigStorage(private val context: Context) {
     suspend fun persistSwitchNotices(enabled: Boolean) {
         context.perAppDataStore.edit { preferences ->
             preferences[switchNoticesKey] = enabled
+        }
+    }
+
+    /** Whether AutoTDP switch notices include the per-app values that override global defaults. */
+    val switchNoticeDetails: Flow<Boolean> = context.perAppDataStore.data.map { preferences ->
+        preferences[switchNoticeDetailsKey] ?: true
+    }
+
+    suspend fun persistSwitchNoticeDetails(enabled: Boolean) {
+        context.perAppDataStore.edit { preferences ->
+            preferences[switchNoticeDetailsKey] = enabled
         }
     }
 

--- a/app/src/main/java/com/kei/pulse/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/kei/pulse/ui/SettingsScreen.kt
@@ -112,6 +112,8 @@ fun SettingsScreen(
     onOpenPerApps: () -> Unit = {},
     perAppSwitchNotices: Boolean = true,
     onPerAppSwitchNoticesChange: (Boolean) -> Unit = {},
+    perAppSwitchNoticeDetails: Boolean = true,
+    onPerAppSwitchNoticeDetailsChange: (Boolean) -> Unit = {},
     overlayEnabled: Boolean = false,
     overlayPreset: OverlayPreset = OverlayPreset.COMPACT,
     overlayElements: Set<OverlayElement> = OverlayPreset.COMPACT.elements,
@@ -364,6 +366,31 @@ fun SettingsScreen(
                 Switch(
                     checked = perAppSwitchNotices,
                     onCheckedChange = onPerAppSwitchNoticesChange,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "AutoTDP notification details",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = "Include per-app FPS target, aggressive parking, and efficiency overrides.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                Switch(
+                    checked = perAppSwitchNoticeDetails,
+                    onCheckedChange = onPerAppSwitchNoticeDetailsChange,
+                    enabled = perAppSwitchNotices,
                 )
             }
         }

--- a/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
+++ b/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
@@ -93,6 +93,10 @@ class TunerViewModel(
     val perAppSwitchNotices: StateFlow<Boolean> = (perAppConfigStorage?.switchNotices ?: flowOf(true))
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
+    val perAppSwitchNoticeDetails: StateFlow<Boolean> =
+        (perAppConfigStorage?.switchNoticeDetails ?: flowOf(true))
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
     val perAppBatteryWh: StateFlow<Float> = (perAppConfigStorage?.batteryCapacityWh ?: flowOf(0f))
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0f)
 
@@ -110,6 +114,12 @@ class TunerViewModel(
     fun setPerAppSwitchNotices(enabled: Boolean) {
         viewModelScope.launch {
             perAppConfigStorage?.persistSwitchNotices(enabled)
+        }
+    }
+
+    fun setPerAppSwitchNoticeDetails(enabled: Boolean) {
+        viewModelScope.launch {
+            perAppConfigStorage?.persistSwitchNoticeDetails(enabled)
         }
     }
 

--- a/app/src/test/java/com/kei/pulse/appwatch/AutoTdpNoticeTest.kt
+++ b/app/src/test/java/com/kei/pulse/appwatch/AutoTdpNoticeTest.kt
@@ -97,7 +97,9 @@ class AutoTdpNoticeTest {
             config,
             global,
         )
-        val settingGroups = notice.expanded.split("  ◆$nonBreakingSpace").drop(1)
+        val settingGroups = notice.expanded.split(
+            "$SETTING_GROUP_WRAP_OPPORTUNITY$SETTING_GROUP_MARKER$nonBreakingSpace",
+        ).drop(1)
 
         assertEquals(3, settingGroups.size)
         assertEquals(

--- a/app/src/test/java/com/kei/pulse/appwatch/AutoTdpNoticeTest.kt
+++ b/app/src/test/java/com/kei/pulse/appwatch/AutoTdpNoticeTest.kt
@@ -1,0 +1,99 @@
+package com.kei.pulse.appwatch
+
+import com.kei.pulse.model.AppSettings
+import com.kei.pulse.model.AutoTdpBias
+import com.kei.pulse.model.PerAppConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutoTdpNoticeTest {
+    private val global = AppSettings(
+        autoTdpFpsTarget = 60,
+        autoTdpAggressivePark = true,
+        autoTdpBias = AutoTdpBias.EFFICIENT,
+    )
+
+    @Test
+    fun `includes every AutoTDP value that differs from global`() {
+        val config = PerAppConfig(
+            packageName = "game",
+            profileBinding = PerAppConfig.AUTO_BINDING,
+            fpsTarget = 30,
+            aggressivePark = false,
+            bias = AutoTdpBias.SMOOTH,
+        )
+
+        val notice = AutoTdpNotice.text("Game", config, global)
+
+        assertEquals("Game: AutoTDP", notice.compact)
+        assertEquals("Game: AutoTDP  ◆ FPS target › 30  ◆ Aggressive park › Off  ◆ Efficiency › Smooth", notice.expanded)
+    }
+
+    @Test
+    fun `omits inherited and global-matching AutoTDP values`() {
+        val inherited = PerAppConfig(
+            packageName = "game",
+            profileBinding = PerAppConfig.AUTO_BINDING,
+        )
+        val matching = inherited.copy(
+            fpsTarget = 60,
+            aggressivePark = true,
+            bias = AutoTdpBias.EFFICIENT,
+        )
+
+        assertEquals(AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP"), AutoTdpNotice.text("Game", inherited, global))
+        assertEquals(AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP"), AutoTdpNotice.text("Game", matching, global))
+    }
+
+    @Test
+    fun `labels the legacy uncapped FPS target as Max`() {
+        val config = PerAppConfig(
+            packageName = "game",
+            profileBinding = PerAppConfig.AUTO_BINDING,
+            fpsTarget = 0,
+        )
+
+        assertEquals(
+            AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP  ◆ FPS target › Max"),
+            AutoTdpNotice.text("Game", config, global),
+        )
+    }
+
+    @Test
+    fun `can suppress override details while keeping the basic notice`() {
+        val config = PerAppConfig(
+            packageName = "game",
+            profileBinding = PerAppConfig.AUTO_BINDING,
+            fpsTarget = 30,
+            aggressivePark = false,
+            bias = AutoTdpBias.SMOOTH,
+        )
+
+        assertEquals(
+            AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP"),
+            AutoTdpNotice.text("Game", config, global, includeOverrides = false),
+        )
+    }
+
+    @Test
+    fun `long app labels keep every setting group indivisible`() {
+        val config = PerAppConfig(
+            packageName = "game",
+            profileBinding = PerAppConfig.AUTO_BINDING,
+            fpsTarget = 30,
+            aggressivePark = false,
+            bias = AutoTdpBias.SMOOTH,
+        )
+
+        val notice = AutoTdpNotice.text(
+            "A Very Long Game Name That Uses Most Of The Available Notification Width",
+            config,
+            global,
+        )
+        val settingGroups = notice.expanded.split("  ◆ ").drop(1)
+
+        assertEquals(3, settingGroups.size)
+        assertEquals(listOf("FPS target › 30", "Aggressive park › Off", "Efficiency › Smooth"), settingGroups)
+        settingGroups.forEach { group -> assertEquals(-1, group.indexOf(' ')) }
+    }
+}

--- a/app/src/test/java/com/kei/pulse/appwatch/AutoTdpNoticeTest.kt
+++ b/app/src/test/java/com/kei/pulse/appwatch/AutoTdpNoticeTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AutoTdpNoticeTest {
+    private val nonBreakingSpace = SETTING_NON_BREAKING_SPACE
     private val global = AppSettings(
         autoTdpFpsTarget = 60,
         autoTdpAggressivePark = true,
@@ -26,7 +27,13 @@ class AutoTdpNoticeTest {
         val notice = AutoTdpNotice.text("Game", config, global)
 
         assertEquals("Game: AutoTDP", notice.compact)
-        assertEquals("Game: AutoTDP  ◆ FPS target › 30  ◆ Aggressive park › Off  ◆ Efficiency › Smooth", notice.expanded)
+        assertEquals(
+            "Game: AutoTDP  ◆${nonBreakingSpace}FPS${nonBreakingSpace}target${nonBreakingSpace}›" +
+                "${nonBreakingSpace}30  ◆${nonBreakingSpace}Aggressive${nonBreakingSpace}park" +
+                "${nonBreakingSpace}›${nonBreakingSpace}Off  ◆${nonBreakingSpace}Efficiency" +
+                "${nonBreakingSpace}›${nonBreakingSpace}Smooth",
+            notice.expanded,
+        )
     }
 
     @Test
@@ -41,8 +48,8 @@ class AutoTdpNoticeTest {
             bias = AutoTdpBias.EFFICIENT,
         )
 
-        assertEquals(AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP"), AutoTdpNotice.text("Game", inherited, global))
-        assertEquals(AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP"), AutoTdpNotice.text("Game", matching, global))
+        assertEquals(AutoTdpNoticeText("Game", emptyList()), AutoTdpNotice.text("Game", inherited, global))
+        assertEquals(AutoTdpNoticeText("Game", emptyList()), AutoTdpNotice.text("Game", matching, global))
     }
 
     @Test
@@ -54,7 +61,7 @@ class AutoTdpNoticeTest {
         )
 
         assertEquals(
-            AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP  ◆ FPS target › Max"),
+            AutoTdpNoticeText("Game", listOf(AutoTdpNoticeSetting("FPS target", "Max"))),
             AutoTdpNotice.text("Game", config, global),
         )
     }
@@ -70,7 +77,7 @@ class AutoTdpNoticeTest {
         )
 
         assertEquals(
-            AutoTdpNoticeText("Game: AutoTDP", "Game: AutoTDP"),
+            AutoTdpNoticeText("Game", emptyList()),
             AutoTdpNotice.text("Game", config, global, includeOverrides = false),
         )
     }
@@ -90,10 +97,17 @@ class AutoTdpNoticeTest {
             config,
             global,
         )
-        val settingGroups = notice.expanded.split("  ◆ ").drop(1)
+        val settingGroups = notice.expanded.split("  ◆$nonBreakingSpace").drop(1)
 
         assertEquals(3, settingGroups.size)
-        assertEquals(listOf("FPS target › 30", "Aggressive park › Off", "Efficiency › Smooth"), settingGroups)
+        assertEquals(
+            listOf(
+                "FPS${nonBreakingSpace}target${nonBreakingSpace}›${nonBreakingSpace}30",
+                "Aggressive${nonBreakingSpace}park${nonBreakingSpace}›${nonBreakingSpace}Off",
+                "Efficiency${nonBreakingSpace}›${nonBreakingSpace}Smooth",
+            ),
+            settingGroups,
+        )
         settingGroups.forEach { group -> assertEquals(-1, group.indexOf(' ')) }
     }
 }


### PR DESCRIPTION
## Problem

When an explicit per-app AutoTDP profile becomes active, the switch notification only says that AutoTDP was applied. It does not identify the per-app values that differ from the global AutoTDP defaults, so users cannot confirm which target and behavior overrides are active without reopening PULSE.

## Changes

- compare the active per-app AutoTDP profile with the current global defaults
- include only differing FPS target, aggressive-parking, and efficiency settings
- add a default-on **AutoTDP notification details** preference beside the existing switch-notification setting
- keep the collapsed notification concise and use `BigTextStyle` for the detailed form
- build structured rich text directly with `SpannableStringBuilder`
- use bold/accented values and muted `◆` / `›` separators
- preserve each complete key/value group with named non-breaking formatting tokens while allowing Android to wrap between groups
- omit inherited or global-matching values to avoid noise

Example expanded content:

`Game: AutoTDP  ◆ FPS target › 30  ◆ Aggressive park › Off  ◆ Efficiency › Smooth`

## User impact

Users can verify an active game's effective AutoTDP overrides directly from the notification shade. The feature is optional: disabling notification details retains the existing concise AutoTDP switch notice.

## Validation

- `./gradlew testDebugUnitTest assembleDebug`
- unit coverage includes all override fields, inherited and matching values, the legacy `Max` target, details-disabled behavior, and long app labels with indivisible setting groups
- hardware validation has not been performed by the contributor

## AI assistance disclosure

This change was created with assistance from ChatGPT using the GPT-5 model. The contributor reviewed the resulting code and ran the validation listed above.
