### PR TITLE
Parse compact CPU list ranges from sysfs

### DIFF
--- a/app/src/main/java/com/kei/pulse/data/CpuPolicyDetector.kt
+++ b/app/src/main/java/com/kei/pulse/data/CpuPolicyDetector.kt
@@ -90,8 +90,23 @@ class CpuPolicyDetector(
 
     internal fun parseCpuIds(raw: String?): List<Int> {
         return raw.orEmpty()
-            .split(Regex("\\s+"))
-            .mapNotNull { it.toIntOrNull() }
+            .split(Regex("[\\s,]+"))
+            .flatMap { token ->
+                val bounds = token.split('-', limit = 2)
+                when (bounds.size) {
+                    1 -> listOfNotNull(bounds[0].toIntOrNull())
+                    2 -> {
+                        val first = bounds[0].toIntOrNull()
+                        val last = bounds[1].toIntOrNull()
+                        if (first != null && last != null && first <= last) {
+                            (first..last).toList()
+                        } else {
+                            emptyList()
+                        }
+                    }
+                    else -> emptyList()
+                }
+            }
             .distinct()
             .sorted()
     }

--- a/app/src/test/java/com/kei/pulse/data/CpuPolicyDetectorTest.kt
+++ b/app/src/test/java/com/kei/pulse/data/CpuPolicyDetectorTest.kt
@@ -6,13 +6,34 @@ import org.junit.Test
 
 class CpuPolicyDetectorTest {
 
+    private val detector = CpuPolicyDetector(
+        privilegedReader = FakePrivilegedSysfsReader(emptyMap()),
+    )
+
     @Test
     fun `parses compact sysfs cpu list ranges`() {
-        val detector = CpuPolicyDetector(
-            privilegedReader = FakePrivilegedSysfsReader(emptyMap()),
-        )
-
         assertEquals(listOf(0, 1, 2, 3, 6, 8, 9), detector.parseCpuIds("0-3,6,8-9"))
+    }
+
+    @Test
+    fun `parses mixed whitespace and comma separators`() {
+        assertEquals(listOf(0, 1, 2, 4, 6), detector.parseCpuIds(" 0-2, 4\n6 "))
+    }
+
+    @Test
+    fun `discards malformed and descending ranges without throwing`() {
+        assertEquals(listOf(5), detector.parseCpuIds("4-2,abc,1-,-3,7-8-9,5"))
+    }
+
+    @Test
+    fun `deduplicates and sorts overlapping ids and ranges`() {
+        assertEquals(listOf(1, 2, 3), detector.parseCpuIds("3,1-3,2,3"))
+    }
+
+    @Test
+    fun `returns no ids for null or blank input`() {
+        assertTrue(detector.parseCpuIds(null).isEmpty())
+        assertTrue(detector.parseCpuIds("  \n ").isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/kei/pulse/data/CpuPolicyDetectorTest.kt
+++ b/app/src/test/java/com/kei/pulse/data/CpuPolicyDetectorTest.kt
@@ -7,6 +7,15 @@ import org.junit.Test
 class CpuPolicyDetectorTest {
 
     @Test
+    fun `parses compact sysfs cpu list ranges`() {
+        val detector = CpuPolicyDetector(
+            privilegedReader = FakePrivilegedSysfsReader(emptyMap()),
+        )
+
+        assertEquals(listOf(0, 1, 2, 3, 6, 8, 9), detector.parseCpuIds("0-3,6,8-9"))
+    }
+
+    @Test
     fun `detects and sorts policies from sysfs`() {
         val fileSystem = FakeSysfsFileSystem(
             directories = listOf(


### PR DESCRIPTION
## Problem

Linux cpulist files can encode membership with comma-separated inclusive ranges such as 0-3,6,8-9. The parser previously accepted only whitespace-separated integers, causing compact range tokens to be discarded.

## Changes

- accept whitespace and comma separators
- expand valid inclusive ranges
- retain individual IDs
- reject malformed and descending ranges without throwing
- preserve distinct sorted output
- add regression coverage for compact ranges, mixed separators, malformed and descending ranges, overlapping duplicates, null input, and blank input

## User impact

CPU policy discovery retains correct per-policy core membership across both expanded and compact kernel cpulist formats.

## Validation

- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- hardware validation has not been performed by the contributor

## AI assistance disclosure

This change was created with assistance from ChatGPT using the GPT-5 model. The contributor reviewed the resulting code and ran the validation listed above.