### PR TITLE
Centralize effective AutoTDP settings

### DIFF
--- a/app/src/main/java/com/kei/pulse/appwatch/AutoTdpEffectiveSettings.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/AutoTdpEffectiveSettings.kt
@@ -3,6 +3,7 @@ package com.kei.pulse.appwatch
 import com.kei.pulse.model.AppSettings
 import com.kei.pulse.model.AutoTdpBias
 import com.kei.pulse.model.PerAppConfig
+import com.kei.pulse.model.resolveEffectiveAutoTdpValues
 
 /** The complete effective AutoTDP policy after applying per-app-over-global precedence and device limits. */
 internal data class AutoTdpEffectiveSettings(
@@ -20,14 +21,15 @@ internal fun resolveAutoTdpSettings(
     soc: String?,
     maxRefreshRate: Int,
 ): AutoTdpEffectiveSettings {
+    val values = resolveEffectiveAutoTdpValues(config, global)
     val target = PerAppConfig.snapFpsTarget(
-        config?.fpsTarget ?: global.autoTdpFpsTarget,
+        values.fpsTarget,
         PerAppConfig.fpsTargetsFor(soc),
     )
     return AutoTdpEffectiveSettings(
         targetFps = target,
-        aggressivePark = config?.aggressivePark ?: global.autoTdpAggressivePark,
-        bias = AutoTdpBias.resolve(config?.bias, global.autoTdpBias),
+        aggressivePark = values.aggressivePark,
+        bias = values.bias,
         frameRatePath = if (PerAppConfig.useGameModeCap(soc, target, maxRefreshRate)) {
             AutoTdpEffectiveSettings.FrameRatePath.GAME_MODE_CAP
         } else {

--- a/app/src/main/java/com/kei/pulse/appwatch/AutoTdpEffectiveSettings.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/AutoTdpEffectiveSettings.kt
@@ -1,0 +1,37 @@
+package com.kei.pulse.appwatch
+
+import com.kei.pulse.model.AppSettings
+import com.kei.pulse.model.AutoTdpBias
+import com.kei.pulse.model.PerAppConfig
+
+/** The complete effective AutoTDP policy after applying per-app-over-global precedence and device limits. */
+internal data class AutoTdpEffectiveSettings(
+    val targetFps: Int,
+    val aggressivePark: Boolean,
+    val bias: AutoTdpBias,
+    val frameRatePath: FrameRatePath,
+) {
+    enum class FrameRatePath { GAME_MODE_CAP, REFRESH_RATE }
+}
+
+internal fun resolveAutoTdpSettings(
+    config: PerAppConfig?,
+    global: AppSettings,
+    soc: String?,
+    maxRefreshRate: Int,
+): AutoTdpEffectiveSettings {
+    val target = PerAppConfig.snapFpsTarget(
+        config?.fpsTarget ?: global.autoTdpFpsTarget,
+        PerAppConfig.fpsTargetsFor(soc),
+    )
+    return AutoTdpEffectiveSettings(
+        targetFps = target,
+        aggressivePark = config?.aggressivePark ?: global.autoTdpAggressivePark,
+        bias = AutoTdpBias.resolve(config?.bias, global.autoTdpBias),
+        frameRatePath = if (PerAppConfig.useGameModeCap(soc, target, maxRefreshRate)) {
+            AutoTdpEffectiveSettings.FrameRatePath.GAME_MODE_CAP
+        } else {
+            AutoTdpEffectiveSettings.FrameRatePath.REFRESH_RATE
+        },
+    )
+}

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -1383,15 +1383,16 @@ class ForegroundAppMonitorService : Service() {
     private suspend fun applyAutoTdpRegulation(pkg: String, config: PerAppConfig?) {
         val settings = container.settingsStorage.settings.first()
         val soc = container.repository.socModel()
-        // Snap to this SoC's valid options so a legacy 45/0 or an Odin value carried onto an 8 Gen 2 can't slip through.
-        val target = PerAppConfig.snapFpsTarget(
-            config?.fpsTarget ?: settings.autoTdpFpsTarget,
-            PerAppConfig.fpsTargetsFor(soc),
+        val maxRefresh = RefreshRateController.RATES.max()
+        val effective = resolveAutoTdpSettings(
+            config = config,
+            global = settings,
+            soc = soc,
+            maxRefreshRate = maxRefresh,
         )
-        autoTune.targetFps = target
-        // Per-app parking / bias override the global default (per-app-first).
-        autoTune.aggressivePark = config?.aggressivePark ?: settings.autoTdpAggressivePark
-        autoTune.bias = AutoTdpBias.resolve(config?.bias, settings.autoTdpBias)
+        autoTune.targetFps = effective.targetFps
+        autoTune.aggressivePark = effective.aggressivePark
+        autoTune.bias = effective.bias
         // Odin-only watt cap + prime-walled settle. The SD 8 Gen 2 (Thor/RP6) has a scaling prime + different
         // chassis, so it just chases the target there (the thermal ceiling stays as the universal backstop).
         autoTune.wattCapAndSettleEnabled = AutoTuneController.appliesOdinPowerTuning(soc)
@@ -1399,17 +1400,19 @@ class ForegroundAppMonitorService : Service() {
         // when the SoC honors it AND the target evenly divides 120 — 30/40/60/120 cap cleanly. 90 can't be
         // frame-paced at 120 Hz (floors to 60), and the 8 Gen 2 (Thor/RP6) doesn't honor the cap at all; both
         // take the refresh-rate path (the panel rate IS the cap). The clock loop holds [target].
-        val maxRefresh = RefreshRateController.RATES.max()
-        if (PerAppConfig.useGameModeCap(soc, target, maxRefresh)) {
+        if (effective.frameRatePath == AutoTdpEffectiveSettings.FrameRatePath.GAME_MODE_CAP) {
             refreshRateController.setRate(maxRefresh)
-            val applied = FrameLimiter.setCap(pkg, target)
+            val applied = FrameLimiter.setCap(pkg, effective.targetFps)
             // Confirm the firmware honored the value (not floored) — read it back in the diagnostic log.
             if (AUTO_DEBUG) {
-                android.util.Log.d("PulseAutoTdp", "FRAME-CAP requested=$target applied=[${applied?.trim()}]")
+                android.util.Log.d(
+                    "PulseAutoTdp",
+                    "FRAME-CAP requested=${effective.targetFps} applied=[${applied?.trim()}]",
+                )
             }
         } else {
             FrameLimiter.clear(pkg)
-            refreshRateController.setRate(target)
+            refreshRateController.setRate(effective.targetFps)
         }
     }
 

--- a/app/src/main/java/com/kei/pulse/model/EffectiveAutoTdpValues.kt
+++ b/app/src/main/java/com/kei/pulse/model/EffectiveAutoTdpValues.kt
@@ -1,0 +1,17 @@
+package com.kei.pulse.model
+
+/** Per-app-over-global AutoTDP values before device-specific target validation and enforcement. */
+data class EffectiveAutoTdpValues(
+    val fpsTarget: Int,
+    val aggressivePark: Boolean,
+    val bias: AutoTdpBias,
+)
+
+fun resolveEffectiveAutoTdpValues(
+    config: PerAppConfig?,
+    global: AppSettings,
+): EffectiveAutoTdpValues = EffectiveAutoTdpValues(
+    fpsTarget = config?.fpsTarget ?: global.autoTdpFpsTarget,
+    aggressivePark = config?.aggressivePark ?: global.autoTdpAggressivePark,
+    bias = AutoTdpBias.resolve(config?.bias, global.autoTdpBias),
+)

--- a/app/src/main/java/com/kei/pulse/overlay/QuickAccessPanel.kt
+++ b/app/src/main/java/com/kei/pulse/overlay/QuickAccessPanel.kt
@@ -64,6 +64,7 @@ import com.kei.pulse.model.OverlayPreset
 import com.kei.pulse.model.PerAppConfig
 import com.kei.pulse.model.PowerTier
 import com.kei.pulse.model.RgbMode
+import com.kei.pulse.model.resolveEffectiveAutoTdpValues
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.StateFlow
@@ -357,16 +358,31 @@ private fun performanceItems(
         }
     }
     if (autoOn) {
-        val fps = if (perGame) QuickAccessPerApp.effectiveFps(perApp, settings.autoTdpFpsTarget) else settings.autoTdpFpsTarget
-        items += chipNavItem("Frame target", FPS_OPTIONS.map { it.toString() }, FPS_OPTIONS.indexOf(fps)) { i ->
+        val effective = resolveEffectiveAutoTdpValues(
+            config = if (perGame) {
+                perApp
+            } else {
+                null
+            },
+            global = settings,
+        )
+        items += chipNavItem(
+            "Frame target",
+            FPS_OPTIONS.map { it.toString() },
+            FPS_OPTIONS.indexOf(effective.fpsTarget),
+        ) { i ->
             onAction(QuickAccessAction.SetFpsTarget(FPS_OPTIONS[i]))
         }
-        val bias = if (perGame) QuickAccessPerApp.effectiveBias(perApp, settings.autoTdpBias) else settings.autoTdpBias
-        items += chipNavItem("Bias", AutoTdpBias.entries.map { biasLabel(it) }, AutoTdpBias.entries.indexOf(bias)) { i ->
+        items += chipNavItem(
+            "Bias",
+            AutoTdpBias.entries.map { biasLabel(it) },
+            AutoTdpBias.entries.indexOf(effective.bias),
+        ) { i ->
             onAction(QuickAccessAction.SetBias(AutoTdpBias.entries[i]))
         }
-        val park = if (perGame) QuickAccessPerApp.effectiveAggressivePark(perApp, settings.autoTdpAggressivePark) else settings.autoTdpAggressivePark
-        items += toggleNavItem("Aggressive park", park) { onAction(QuickAccessAction.SetAggressivePark(!park)) }
+        items += toggleNavItem("Aggressive park", effective.aggressivePark) {
+            onAction(QuickAccessAction.SetAggressivePark(!effective.aggressivePark))
+        }
     }
     return items
 }

--- a/app/src/main/java/com/kei/pulse/overlay/QuickAccessPerApp.kt
+++ b/app/src/main/java/com/kei/pulse/overlay/QuickAccessPerApp.kt
@@ -1,6 +1,5 @@
 package com.kei.pulse.overlay
 
-import com.kei.pulse.model.AutoTdpBias
 import com.kei.pulse.model.PerAppConfig
 
 /**
@@ -72,13 +71,4 @@ object QuickAccessPerApp {
             else -> false                          // a tier/Custom binding ⇒ AutoTDP not active for this app
         }
 
-    /** The game's effective AutoTDP fps target — its per-app value, else the global default. */
-    fun effectiveFps(config: PerAppConfig?, globalFps: Int): Int = config?.fpsTarget ?: globalFps
-
-    /** The game's effective AutoTDP bias — its per-app value, else the global default. */
-    fun effectiveBias(config: PerAppConfig?, globalDefault: AutoTdpBias): AutoTdpBias = config?.bias ?: globalDefault
-
-    /** The game's effective aggressive-park setting — its per-app value, else the global default. */
-    fun effectiveAggressivePark(config: PerAppConfig?, globalDefault: Boolean): Boolean =
-        config?.aggressivePark ?: globalDefault
 }

--- a/app/src/test/java/com/kei/pulse/appwatch/AutoTdpEffectiveSettingsTest.kt
+++ b/app/src/test/java/com/kei/pulse/appwatch/AutoTdpEffectiveSettingsTest.kt
@@ -1,0 +1,77 @@
+package com.kei.pulse.appwatch
+
+import com.kei.pulse.model.AppSettings
+import com.kei.pulse.model.AutoTdpBias
+import com.kei.pulse.model.PerAppConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutoTdpEffectiveSettingsTest {
+
+    private val global = AppSettings(
+        autoTdpFpsTarget = 60,
+        autoTdpAggressivePark = true,
+        autoTdpBias = AutoTdpBias.EFFICIENT,
+    )
+
+    @Test
+    fun `null per-app values inherit every global AutoTDP setting`() {
+        val resolved = resolveAutoTdpSettings(
+            config = PerAppConfig("game", profileBinding = PerAppConfig.AUTO_BINDING),
+            global = global,
+            soc = "CQ8725S",
+            maxRefreshRate = 120,
+        )
+
+        assertEquals(60, resolved.targetFps)
+        assertEquals(true, resolved.aggressivePark)
+        assertEquals(AutoTdpBias.EFFICIENT, resolved.bias)
+        assertEquals(AutoTdpEffectiveSettings.FrameRatePath.GAME_MODE_CAP, resolved.frameRatePath)
+    }
+
+    @Test
+    fun `per-app values override all global AutoTDP settings together`() {
+        val resolved = resolveAutoTdpSettings(
+            config = PerAppConfig(
+                packageName = "game",
+                profileBinding = PerAppConfig.AUTO_BINDING,
+                fpsTarget = 30,
+                aggressivePark = false,
+                bias = AutoTdpBias.SMOOTH,
+            ),
+            global = global,
+            soc = "CQ8725S",
+            maxRefreshRate = 120,
+        )
+
+        assertEquals(30, resolved.targetFps)
+        assertEquals(false, resolved.aggressivePark)
+        assertEquals(AutoTdpBias.SMOOTH, resolved.bias)
+    }
+
+    @Test
+    fun `legacy target is snapped before choosing the enforcement path`() {
+        val resolved = resolveAutoTdpSettings(
+            config = PerAppConfig("game", profileBinding = PerAppConfig.AUTO_BINDING, fpsTarget = 90),
+            global = global,
+            soc = "CQ8725S",
+            maxRefreshRate = 120,
+        )
+
+        assertEquals(60, resolved.targetFps)
+        assertEquals(AutoTdpEffectiveSettings.FrameRatePath.GAME_MODE_CAP, resolved.frameRatePath)
+    }
+
+    @Test
+    fun `refresh-only devices never select the game-mode cap`() {
+        val resolved = resolveAutoTdpSettings(
+            config = null,
+            global = global.copy(autoTdpFpsTarget = 90),
+            soc = "QCS8550",
+            maxRefreshRate = 120,
+        )
+
+        assertEquals(90, resolved.targetFps)
+        assertEquals(AutoTdpEffectiveSettings.FrameRatePath.REFRESH_RATE, resolved.frameRatePath)
+    }
+}

--- a/app/src/test/java/com/kei/pulse/model/EffectiveAutoTdpValuesTest.kt
+++ b/app/src/test/java/com/kei/pulse/model/EffectiveAutoTdpValuesTest.kt
@@ -1,0 +1,50 @@
+package com.kei.pulse.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EffectiveAutoTdpValuesTest {
+
+    private val global = AppSettings(
+        autoTdpFpsTarget = 60,
+        autoTdpAggressivePark = false,
+        autoTdpBias = AutoTdpBias.EFFICIENT,
+    )
+
+    @Test
+    fun `all per-app values override their global counterparts`() {
+        val values = resolveEffectiveAutoTdpValues(
+            config = PerAppConfig(
+                packageName = "game",
+                fpsTarget = 120,
+                aggressivePark = true,
+                bias = AutoTdpBias.SMOOTH,
+            ),
+            global = global,
+        )
+
+        assertEquals(120, values.fpsTarget)
+        assertEquals(true, values.aggressivePark)
+        assertEquals(AutoTdpBias.SMOOTH, values.bias)
+    }
+
+    @Test
+    fun `null per-app fields inherit their global counterparts`() {
+        val values = resolveEffectiveAutoTdpValues(
+            config = PerAppConfig(packageName = "game"),
+            global = global,
+        )
+
+        assertEquals(60, values.fpsTarget)
+        assertEquals(false, values.aggressivePark)
+        assertEquals(AutoTdpBias.EFFICIENT, values.bias)
+    }
+
+    @Test
+    fun `global scope resolves the same values by omitting the per-app config`() {
+        assertEquals(
+            EffectiveAutoTdpValues(60, false, AutoTdpBias.EFFICIENT),
+            resolveEffectiveAutoTdpValues(config = null, global = global),
+        )
+    }
+}

--- a/app/src/test/java/com/kei/pulse/overlay/QuickAccessPerAppTest.kt
+++ b/app/src/test/java/com/kei/pulse/overlay/QuickAccessPerAppTest.kt
@@ -128,20 +128,4 @@ class QuickAccessPerAppTest {
         )
     }
 
-    @Test
-    fun `effective bias and park fall back to the global when the config has none`() {
-        assertEquals(AutoTdpBias.SMOOTH, QuickAccessPerApp.effectiveBias(PerAppConfig(packageName = pkg, bias = AutoTdpBias.SMOOTH), AutoTdpBias.EFFICIENT))
-        assertEquals(AutoTdpBias.EFFICIENT, QuickAccessPerApp.effectiveBias(PerAppConfig(packageName = pkg, bias = null), AutoTdpBias.EFFICIENT))
-        assertEquals(AutoTdpBias.EFFICIENT, QuickAccessPerApp.effectiveBias(null, AutoTdpBias.EFFICIENT))
-        assertTrue(QuickAccessPerApp.effectiveAggressivePark(PerAppConfig(packageName = pkg, aggressivePark = true), globalDefault = false))
-        assertFalse(QuickAccessPerApp.effectiveAggressivePark(PerAppConfig(packageName = pkg, aggressivePark = null), globalDefault = false))
-        assertTrue(QuickAccessPerApp.effectiveAggressivePark(null, globalDefault = true))
-    }
-
-    @Test
-    fun `effective values fall back to the global when the config has none`() {
-        assertEquals(120, QuickAccessPerApp.effectiveFps(PerAppConfig(packageName = pkg, fpsTarget = 120), globalFps = 60))
-        assertEquals(60, QuickAccessPerApp.effectiveFps(PerAppConfig(packageName = pkg, fpsTarget = null), globalFps = 60))
-        assertEquals(60, QuickAccessPerApp.effectiveFps(null, globalFps = 60))
-    }
 }


### PR DESCRIPTION
## Problem

AutoTDP effective-value precedence was resolved independently in enforcement and Quick Access. That duplication allowed the displayed FPS target, efficiency bias, or aggressive-parking state to drift from the values the service actually enforced.

## Changes

- add one device-free resolver for per-app-over-global AutoTDP values
- use it in both service-side regulation and Quick Access rendering
- keep device-specific FPS snapping and frame-rate-path selection in the enforcement layer
- remove the duplicated Quick Access field helpers
- add unit coverage for per-app overrides, inherited fields, and global scope

## User impact

Quick Access now displays the same effective AutoTDP values that the foreground service consumes, preventing UI and enforcement behavior from diverging as these settings evolve.

## Validation

- ./gradlew testDebugUnitTest
- ./gradlew lintDebug
- hardware validation has not been performed by the contributor

## AI assistance disclosure

This change was created with assistance from ChatGPT using the GPT-5 model. The contributor reviewed the resulting code and ran the validation listed above.