### PR TITLE
Centralize side-control tuning state

### DIFF
--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -281,8 +281,14 @@ class ForegroundAppMonitorService : Service() {
             activeTierLabel = PowerTier.CUSTOM.label, // a Power Target edit is a Custom-tier edit, as in-app
             primeCoreBoostLimited = s.primeCoreBoostLimited,
         )
+        val customTuning = store.customTuning.first()
         store.persistCustomTuning(
-            store.customTuning.first().copy(powerTargetEnabled = enabled, powerTargetPercent = percent),
+            customTuning.copy(
+                sideControls = customTuning.sideControls.copy(
+                    powerTargetEnabled = enabled,
+                    powerTargetPercent = percent,
+                ),
+            ),
         )
         transitionMutex.withLock {
             if (autoTdpPackage != null) {

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -38,7 +38,6 @@ import com.kei.pulse.data.TelemetrySnapshot
 import com.kei.pulse.model.AppSettings
 import com.kei.pulse.model.AutoTdpBias
 import com.kei.pulse.model.CustomFanGate
-import com.kei.pulse.model.toSideControlState
 import com.kei.pulse.model.CustomFanState
 import com.kei.pulse.model.DeviceProfiles
 import com.kei.pulse.model.FanAction
@@ -272,23 +271,17 @@ class ForegroundAppMonitorService : Service() {
     private suspend fun applyQaPowerTarget(percent: Int, enabled: Boolean) {
         val store = container.settingsStorage
         val s = store.settings.first()
-        val sideControls = s.toSideControlState().copy(
-            powerTargetEnabled = enabled,
-            powerTargetPercent = percent,
+        val persistence = resolveQuickAccessPowerTargetPersistence(
+            settings = s,
+            customTuning = store.customTuning.first(),
+            percent = percent,
+            enabled = enabled,
         )
         store.persistTuningState(
-            sideControls = sideControls,
+            sideControls = persistence.liveSideControls,
             activeTierLabel = PowerTier.CUSTOM.label, // a Power Target edit is a Custom-tier edit, as in-app
         )
-        val customTuning = store.customTuning.first()
-        store.persistCustomTuning(
-            customTuning.copy(
-                sideControls = customTuning.sideControls.copy(
-                    powerTargetEnabled = enabled,
-                    powerTargetPercent = percent,
-                ),
-            ),
-        )
+        store.persistCustomTuning(persistence.customTuning)
         transitionMutex.withLock {
             if (autoTdpPackage != null) {
                 android.util.Log.i("PulseQA", "SetPowerTarget $percent% persisted only — AutoTDP owns the clocks")

--- a/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
@@ -38,6 +38,7 @@ import com.kei.pulse.data.TelemetrySnapshot
 import com.kei.pulse.model.AppSettings
 import com.kei.pulse.model.AutoTdpBias
 import com.kei.pulse.model.CustomFanGate
+import com.kei.pulse.model.toSideControlState
 import com.kei.pulse.model.CustomFanState
 import com.kei.pulse.model.DeviceProfiles
 import com.kei.pulse.model.FanAction
@@ -271,15 +272,13 @@ class ForegroundAppMonitorService : Service() {
     private suspend fun applyQaPowerTarget(percent: Int, enabled: Boolean) {
         val store = container.settingsStorage
         val s = store.settings.first()
-        store.persistTuningState(
+        val sideControls = s.toSideControlState().copy(
             powerTargetEnabled = enabled,
             powerTargetPercent = percent,
-            powerTargetCpuOnly = s.powerTargetCpuOnly,
-            gpuLocked = s.gpuLocked,
-            gpuFloorPercent = s.gpuFloorPercent,
-            cpuFloorPercent = s.cpuFloorPercent,
+        )
+        store.persistTuningState(
+            sideControls = sideControls,
             activeTierLabel = PowerTier.CUSTOM.label, // a Power Target edit is a Custom-tier edit, as in-app
-            primeCoreBoostLimited = s.primeCoreBoostLimited,
         )
         val customTuning = store.customTuning.first()
         store.persistCustomTuning(

--- a/app/src/main/java/com/kei/pulse/appwatch/QuickAccessPowerTargetPersistence.kt
+++ b/app/src/main/java/com/kei/pulse/appwatch/QuickAccessPowerTargetPersistence.kt
@@ -1,0 +1,34 @@
+package com.kei.pulse.appwatch
+
+import com.kei.pulse.model.AppSettings
+import com.kei.pulse.model.CustomTuning
+import com.kei.pulse.model.SideControlState
+import com.kei.pulse.model.toSideControlState
+
+/** Pure persistence snapshots for one Quick Access Power Target edit. */
+internal data class QuickAccessPowerTargetPersistence(
+    val liveSideControls: SideControlState,
+    val customTuning: CustomTuning,
+)
+
+/**
+ * Live controls start from current settings, while saved Custom controls start from their own snapshot.
+ * A preset may have cleared the live GPU/floor/boost fields, which must not erase the values Custom restores.
+ */
+internal fun resolveQuickAccessPowerTargetPersistence(
+    settings: AppSettings,
+    customTuning: CustomTuning,
+    percent: Int,
+    enabled: Boolean,
+): QuickAccessPowerTargetPersistence = QuickAccessPowerTargetPersistence(
+    liveSideControls = settings.toSideControlState().copy(
+        powerTargetEnabled = enabled,
+        powerTargetPercent = percent,
+    ),
+    customTuning = customTuning.copy(
+        sideControls = customTuning.sideControls.copy(
+            powerTargetEnabled = enabled,
+            powerTargetPercent = percent,
+        ),
+    ),
+)

--- a/app/src/main/java/com/kei/pulse/data/SettingsStorage.kt
+++ b/app/src/main/java/com/kei/pulse/data/SettingsStorage.kt
@@ -44,15 +44,8 @@ class SettingsStorage(private val context: Context) {
     private val themeIdKey = stringPreferencesKey("theme_id")
     private val colorSourceKey = stringPreferencesKey("color_source")
     private val accentColorKey = intPreferencesKey("accent_color")
-    private val powerTargetEnabledKey = booleanPreferencesKey("power_target_enabled")
-    private val powerTargetPercentKey = intPreferencesKey("power_target_percent")
-    private val powerTargetCpuOnlyKey = booleanPreferencesKey("power_target_cpu_only")
-    private val gpuLockedKey = booleanPreferencesKey("gpu_locked")
-    private val gpuFloorPercentKey = intPreferencesKey("gpu_floor_percent")
-    private val cpuFloorPercentKey = intPreferencesKey("cpu_floor_percent")
     private val managedFanModeKey = intPreferencesKey("managed_fan_mode")
     private val activeTierKey = stringPreferencesKey("active_tier_label")
-    private val primeCoreBoostKey = booleanPreferencesKey("prime_core_boost_limited")
     private val learnedPeakKey = floatPreferencesKey("learned_peak_w")
     private val autoTdpDefaultKey = booleanPreferencesKey("auto_tdp_default_enabled")
     private val autoTdpFpsTargetKey = intPreferencesKey("auto_tdp_fps_target")
@@ -89,16 +82,10 @@ class SettingsStorage(private val context: Context) {
     private val rgbManualRightBrightnessKey = floatPreferencesKey("rgb_manual_right_brightness")
 
     // Custom-mode snapshot: preserved across preset applies so cycling back to Custom restores it.
-    private val customPtEnabledKey = booleanPreferencesKey("custom_pt_enabled")
-    private val customPtPercentKey = intPreferencesKey("custom_pt_percent")
-    private val customPtCpuOnlyKey = booleanPreferencesKey("custom_pt_cpu_only")
-    private val customGpuLockedKey = booleanPreferencesKey("custom_gpu_locked")
-    private val customGpuFloorKey = intPreferencesKey("custom_gpu_floor_percent")
-    private val customCpuFloorKey = intPreferencesKey("custom_cpu_floor_percent")
-    private val customPrimeBoostKey = booleanPreferencesKey("custom_prime_core_boost")
     private val customGovernorLabelKey = stringPreferencesKey("custom_governor_label")
 
     val settings: Flow<AppSettings> = context.settingsDataStore.data.map { preferences ->
+        val sideControls = preferences.readSideControls(LIVE_SIDE_CONTROL_KEYS)
         AppSettings(
             themeId = preferences[themeIdKey]?.let(::parseThemeId) ?: PulseThemeId.SIGNAL,
             colorSource = preferences[colorSourceKey]
@@ -115,15 +102,15 @@ class SettingsStorage(private val context: Context) {
             hasPromptedQuickSettingsTile = preferences[quickSettingsTilePromptShownKey] ?: false,
             isQuickSettingsTileAdded = preferences[quickSettingsTileAddedKey] ?: false,
             batteryOptPromptShown = preferences[batteryOptPromptShownKey] ?: false,
-            powerTargetEnabled = preferences[powerTargetEnabledKey] ?: false,
-            powerTargetPercent = preferences[powerTargetPercentKey] ?: 100,
-            powerTargetCpuOnly = preferences[powerTargetCpuOnlyKey] ?: false,
-            gpuLocked = preferences[gpuLockedKey] ?: false,
-            gpuFloorPercent = preferences[gpuFloorPercentKey] ?: 0,
-            cpuFloorPercent = preferences[cpuFloorPercentKey] ?: 0,
+            powerTargetEnabled = sideControls.powerTargetEnabled,
+            powerTargetPercent = sideControls.powerTargetPercent,
+            powerTargetCpuOnly = sideControls.powerTargetCpuOnly,
+            gpuLocked = sideControls.gpuLocked,
+            gpuFloorPercent = sideControls.gpuFloorPercent,
+            cpuFloorPercent = sideControls.cpuFloorPercent,
             managedFanMode = preferences[managedFanModeKey],
             activeTierLabel = preferences[activeTierKey] ?: "Custom",
-            primeCoreBoostLimited = preferences[primeCoreBoostKey] ?: false,
+            primeCoreBoostLimited = sideControls.primeCoreBoostLimited,
             learnedPeakW = preferences[learnedPeakKey] ?: 0f,
             autoTdpDefaultEnabled = preferences[autoTdpDefaultKey] ?: false,
             autoTdpFpsTarget = preferences[autoTdpFpsTargetKey] ?: 60,
@@ -356,29 +343,14 @@ class SettingsStorage(private val context: Context) {
 
     val customTuning: Flow<CustomTuning> = context.settingsDataStore.data.map { preferences ->
         CustomTuning(
-            sideControls = SideControlState(
-                powerTargetEnabled = preferences[customPtEnabledKey] ?: false,
-                powerTargetPercent = preferences[customPtPercentKey] ?: 100,
-                powerTargetCpuOnly = preferences[customPtCpuOnlyKey] ?: false,
-                gpuLocked = preferences[customGpuLockedKey] ?: false,
-                gpuFloorPercent = preferences[customGpuFloorKey] ?: 0,
-                cpuFloorPercent = preferences[customCpuFloorKey] ?: 0,
-                primeCoreBoostLimited = preferences[customPrimeBoostKey] ?: false,
-            ),
+            sideControls = preferences.readSideControls(CUSTOM_SIDE_CONTROL_KEYS),
             governorLabel = preferences[customGovernorLabelKey],
         )
     }
 
     suspend fun persistCustomTuning(tuning: CustomTuning) {
         withContext(NonCancellable) { context.settingsDataStore.edit { preferences ->
-            val sideControls = tuning.sideControls
-            preferences[customPtEnabledKey] = sideControls.powerTargetEnabled
-            preferences[customPtPercentKey] = sideControls.powerTargetPercent
-            preferences[customPtCpuOnlyKey] = sideControls.powerTargetCpuOnly
-            preferences[customGpuLockedKey] = sideControls.gpuLocked
-            preferences[customGpuFloorKey] = sideControls.gpuFloorPercent
-            preferences[customCpuFloorKey] = sideControls.cpuFloorPercent
-            preferences[customPrimeBoostKey] = sideControls.primeCoreBoostLimited
+            preferences.putSideControls(CUSTOM_SIDE_CONTROL_KEYS, tuning.sideControls)
             // Preferences DataStore can't hold null — remove the key when no governor is remembered.
             tuning.governorLabel
                 ?.let { preferences[customGovernorLabelKey] = it }
@@ -479,14 +451,8 @@ class SettingsStorage(private val context: Context) {
         activeTierLabel: String,
     ) {
         withContext(NonCancellable) { context.settingsDataStore.edit { preferences ->
-            preferences[powerTargetEnabledKey] = sideControls.powerTargetEnabled
-            preferences[powerTargetPercentKey] = sideControls.powerTargetPercent
-            preferences[powerTargetCpuOnlyKey] = sideControls.powerTargetCpuOnly
-            preferences[gpuLockedKey] = sideControls.gpuLocked
-            preferences[gpuFloorPercentKey] = sideControls.gpuFloorPercent
-            preferences[cpuFloorPercentKey] = sideControls.cpuFloorPercent
+            preferences.putSideControls(LIVE_SIDE_CONTROL_KEYS, sideControls)
             preferences[activeTierKey] = activeTierLabel
-            preferences[primeCoreBoostKey] = sideControls.primeCoreBoostLimited
         } }
     }
 

--- a/app/src/main/java/com/kei/pulse/data/SettingsStorage.kt
+++ b/app/src/main/java/com/kei/pulse/data/SettingsStorage.kt
@@ -475,24 +475,18 @@ class SettingsStorage(private val context: Context) {
     }
 
     suspend fun persistTuningState(
-        powerTargetEnabled: Boolean,
-        powerTargetPercent: Int,
-        powerTargetCpuOnly: Boolean,
-        gpuLocked: Boolean,
-        gpuFloorPercent: Int,
-        cpuFloorPercent: Int,
+        sideControls: SideControlState,
         activeTierLabel: String,
-        primeCoreBoostLimited: Boolean,
     ) {
         withContext(NonCancellable) { context.settingsDataStore.edit { preferences ->
-            preferences[powerTargetEnabledKey] = powerTargetEnabled
-            preferences[powerTargetPercentKey] = powerTargetPercent
-            preferences[powerTargetCpuOnlyKey] = powerTargetCpuOnly
-            preferences[gpuLockedKey] = gpuLocked
-            preferences[gpuFloorPercentKey] = gpuFloorPercent
-            preferences[cpuFloorPercentKey] = cpuFloorPercent
+            preferences[powerTargetEnabledKey] = sideControls.powerTargetEnabled
+            preferences[powerTargetPercentKey] = sideControls.powerTargetPercent
+            preferences[powerTargetCpuOnlyKey] = sideControls.powerTargetCpuOnly
+            preferences[gpuLockedKey] = sideControls.gpuLocked
+            preferences[gpuFloorPercentKey] = sideControls.gpuFloorPercent
+            preferences[cpuFloorPercentKey] = sideControls.cpuFloorPercent
             preferences[activeTierKey] = activeTierLabel
-            preferences[primeCoreBoostKey] = primeCoreBoostLimited
+            preferences[primeCoreBoostKey] = sideControls.primeCoreBoostLimited
         } }
     }
 

--- a/app/src/main/java/com/kei/pulse/data/SettingsStorage.kt
+++ b/app/src/main/java/com/kei/pulse/data/SettingsStorage.kt
@@ -17,6 +17,7 @@ import com.kei.pulse.model.OverlayPreset
 import com.kei.pulse.model.AutoTdpBias
 import com.kei.pulse.model.RgbMode
 import com.kei.pulse.model.RgbStick
+import com.kei.pulse.model.SideControlState
 import com.kei.pulse.model.PulseThemeId
 import com.kei.pulse.model.TileInteractionBehavior
 import kotlinx.coroutines.flow.Flow
@@ -355,26 +356,29 @@ class SettingsStorage(private val context: Context) {
 
     val customTuning: Flow<CustomTuning> = context.settingsDataStore.data.map { preferences ->
         CustomTuning(
-            powerTargetEnabled = preferences[customPtEnabledKey] ?: false,
-            powerTargetPercent = preferences[customPtPercentKey] ?: 100,
-            powerTargetCpuOnly = preferences[customPtCpuOnlyKey] ?: false,
-            gpuLocked = preferences[customGpuLockedKey] ?: false,
-            gpuFloorPercent = preferences[customGpuFloorKey] ?: 0,
-            cpuFloorPercent = preferences[customCpuFloorKey] ?: 0,
-            primeCoreBoostLimited = preferences[customPrimeBoostKey] ?: false,
+            sideControls = SideControlState(
+                powerTargetEnabled = preferences[customPtEnabledKey] ?: false,
+                powerTargetPercent = preferences[customPtPercentKey] ?: 100,
+                powerTargetCpuOnly = preferences[customPtCpuOnlyKey] ?: false,
+                gpuLocked = preferences[customGpuLockedKey] ?: false,
+                gpuFloorPercent = preferences[customGpuFloorKey] ?: 0,
+                cpuFloorPercent = preferences[customCpuFloorKey] ?: 0,
+                primeCoreBoostLimited = preferences[customPrimeBoostKey] ?: false,
+            ),
             governorLabel = preferences[customGovernorLabelKey],
         )
     }
 
     suspend fun persistCustomTuning(tuning: CustomTuning) {
         withContext(NonCancellable) { context.settingsDataStore.edit { preferences ->
-            preferences[customPtEnabledKey] = tuning.powerTargetEnabled
-            preferences[customPtPercentKey] = tuning.powerTargetPercent
-            preferences[customPtCpuOnlyKey] = tuning.powerTargetCpuOnly
-            preferences[customGpuLockedKey] = tuning.gpuLocked
-            preferences[customGpuFloorKey] = tuning.gpuFloorPercent
-            preferences[customCpuFloorKey] = tuning.cpuFloorPercent
-            preferences[customPrimeBoostKey] = tuning.primeCoreBoostLimited
+            val sideControls = tuning.sideControls
+            preferences[customPtEnabledKey] = sideControls.powerTargetEnabled
+            preferences[customPtPercentKey] = sideControls.powerTargetPercent
+            preferences[customPtCpuOnlyKey] = sideControls.powerTargetCpuOnly
+            preferences[customGpuLockedKey] = sideControls.gpuLocked
+            preferences[customGpuFloorKey] = sideControls.gpuFloorPercent
+            preferences[customCpuFloorKey] = sideControls.cpuFloorPercent
+            preferences[customPrimeBoostKey] = sideControls.primeCoreBoostLimited
             // Preferences DataStore can't hold null — remove the key when no governor is remembered.
             tuning.governorLabel
                 ?.let { preferences[customGovernorLabelKey] = it }

--- a/app/src/main/java/com/kei/pulse/data/SideControlPreferences.kt
+++ b/app/src/main/java/com/kei/pulse/data/SideControlPreferences.kt
@@ -1,0 +1,61 @@
+package com.kei.pulse.data
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.kei.pulse.model.SideControlState
+
+internal data class SideControlPreferenceKeys(
+    val powerTargetEnabled: Preferences.Key<Boolean>,
+    val powerTargetPercent: Preferences.Key<Int>,
+    val powerTargetCpuOnly: Preferences.Key<Boolean>,
+    val gpuLocked: Preferences.Key<Boolean>,
+    val gpuFloorPercent: Preferences.Key<Int>,
+    val cpuFloorPercent: Preferences.Key<Int>,
+    val primeCoreBoostLimited: Preferences.Key<Boolean>,
+)
+
+internal val LIVE_SIDE_CONTROL_KEYS = SideControlPreferenceKeys(
+    powerTargetEnabled = booleanPreferencesKey("power_target_enabled"),
+    powerTargetPercent = intPreferencesKey("power_target_percent"),
+    powerTargetCpuOnly = booleanPreferencesKey("power_target_cpu_only"),
+    gpuLocked = booleanPreferencesKey("gpu_locked"),
+    gpuFloorPercent = intPreferencesKey("gpu_floor_percent"),
+    cpuFloorPercent = intPreferencesKey("cpu_floor_percent"),
+    primeCoreBoostLimited = booleanPreferencesKey("prime_core_boost_limited"),
+)
+
+internal val CUSTOM_SIDE_CONTROL_KEYS = SideControlPreferenceKeys(
+    powerTargetEnabled = booleanPreferencesKey("custom_pt_enabled"),
+    powerTargetPercent = intPreferencesKey("custom_pt_percent"),
+    powerTargetCpuOnly = booleanPreferencesKey("custom_pt_cpu_only"),
+    gpuLocked = booleanPreferencesKey("custom_gpu_locked"),
+    gpuFloorPercent = intPreferencesKey("custom_gpu_floor_percent"),
+    cpuFloorPercent = intPreferencesKey("custom_cpu_floor_percent"),
+    primeCoreBoostLimited = booleanPreferencesKey("custom_prime_core_boost"),
+)
+
+internal fun Preferences.readSideControls(keys: SideControlPreferenceKeys): SideControlState =
+    SideControlState(
+        powerTargetEnabled = this[keys.powerTargetEnabled] ?: false,
+        powerTargetPercent = this[keys.powerTargetPercent] ?: 100,
+        powerTargetCpuOnly = this[keys.powerTargetCpuOnly] ?: false,
+        gpuLocked = this[keys.gpuLocked] ?: false,
+        gpuFloorPercent = this[keys.gpuFloorPercent] ?: 0,
+        cpuFloorPercent = this[keys.cpuFloorPercent] ?: 0,
+        primeCoreBoostLimited = this[keys.primeCoreBoostLimited] ?: false,
+    )
+
+internal fun MutablePreferences.putSideControls(
+    keys: SideControlPreferenceKeys,
+    sideControls: SideControlState,
+) {
+    this[keys.powerTargetEnabled] = sideControls.powerTargetEnabled
+    this[keys.powerTargetPercent] = sideControls.powerTargetPercent
+    this[keys.powerTargetCpuOnly] = sideControls.powerTargetCpuOnly
+    this[keys.gpuLocked] = sideControls.gpuLocked
+    this[keys.gpuFloorPercent] = sideControls.gpuFloorPercent
+    this[keys.cpuFloorPercent] = sideControls.cpuFloorPercent
+    this[keys.primeCoreBoostLimited] = sideControls.primeCoreBoostLimited
+}

--- a/app/src/main/java/com/kei/pulse/model/AppSettings.kt
+++ b/app/src/main/java/com/kei/pulse/model/AppSettings.kt
@@ -175,3 +175,25 @@ data class AppSettings(
     val rgbManualRightColor: Int = 0xFF3F6BFF.toInt(),
     val rgbManualRightBrightness: Float = 1f,
 )
+
+/** Flattened settings boundary for the seven side-controls that always travel together. */
+fun AppSettings.toSideControlState(): SideControlState = SideControlState(
+    powerTargetEnabled = powerTargetEnabled,
+    powerTargetPercent = powerTargetPercent,
+    powerTargetCpuOnly = powerTargetCpuOnly,
+    gpuLocked = gpuLocked,
+    gpuFloorPercent = gpuFloorPercent,
+    cpuFloorPercent = cpuFloorPercent,
+    primeCoreBoostLimited = primeCoreBoostLimited,
+)
+
+/** Replace all seven flattened side-controls while preserving every unrelated setting. */
+fun AppSettings.withSideControls(sideControls: SideControlState): AppSettings = copy(
+    powerTargetEnabled = sideControls.powerTargetEnabled,
+    powerTargetPercent = sideControls.powerTargetPercent,
+    powerTargetCpuOnly = sideControls.powerTargetCpuOnly,
+    gpuLocked = sideControls.gpuLocked,
+    gpuFloorPercent = sideControls.gpuFloorPercent,
+    cpuFloorPercent = sideControls.cpuFloorPercent,
+    primeCoreBoostLimited = sideControls.primeCoreBoostLimited,
+)

--- a/app/src/main/java/com/kei/pulse/model/CustomTuning.kt
+++ b/app/src/main/java/com/kei/pulse/model/CustomTuning.kt
@@ -7,13 +7,7 @@ package com.kei.pulse.model
  * when the user cycles back to Custom from a preset.
  */
 data class CustomTuning(
-    val powerTargetEnabled: Boolean = false,
-    val powerTargetPercent: Int = 100,
-    val powerTargetCpuOnly: Boolean = false,
-    val gpuLocked: Boolean = false,
-    val gpuFloorPercent: Int = 0,
-    val cpuFloorPercent: Int = 0,
-    val primeCoreBoostLimited: Boolean = false,
+    val sideControls: SideControlState = SideControlState(),
     /** GovernorController.OPTIONS label the user last chose while in Custom; null = leave alone. */
     val governorLabel: String? = null,
 )

--- a/app/src/main/java/com/kei/pulse/model/TierTransition.kt
+++ b/app/src/main/java/com/kei/pulse/model/TierTransition.kt
@@ -13,25 +13,17 @@ package com.kei.pulse.model
  * path (it is not a plain flag), so it is intentionally not modeled here.
  */
 data class SideControlState(
-    val powerTargetEnabled: Boolean,
-    val powerTargetPercent: Int,
-    val powerTargetCpuOnly: Boolean,
-    val gpuLocked: Boolean,
-    val gpuFloorPercent: Int,
-    val cpuFloorPercent: Int,
-    val primeCoreBoostLimited: Boolean,
+    val powerTargetEnabled: Boolean = false,
+    val powerTargetPercent: Int = 100,
+    val powerTargetCpuOnly: Boolean = false,
+    val gpuLocked: Boolean = false,
+    val gpuFloorPercent: Int = 0,
+    val cpuFloorPercent: Int = 0,
+    val primeCoreBoostLimited: Boolean = false,
 ) {
     companion object {
         /** All side-controls at their neutral defaults (nothing governing). */
-        val CLEARED = SideControlState(
-            powerTargetEnabled = false,
-            powerTargetPercent = 100,
-            powerTargetCpuOnly = false,
-            gpuLocked = false,
-            gpuFloorPercent = 0,
-            cpuFloorPercent = 0,
-            primeCoreBoostLimited = false,
-        )
+        val CLEARED = SideControlState()
     }
 }
 

--- a/app/src/main/java/com/kei/pulse/model/TierTransition.kt
+++ b/app/src/main/java/com/kei/pulse/model/TierTransition.kt
@@ -48,15 +48,7 @@ object TierTransition {
      * Side-control state after switching to CUSTOM: restore every saved knob. A [CustomTuning] flag
      * with no mapping here is a restoration bug — the saved value would be silently dropped.
      */
-    fun afterCustomRestore(saved: CustomTuning): SideControlState = SideControlState(
-        powerTargetEnabled = saved.powerTargetEnabled,
-        powerTargetPercent = saved.powerTargetPercent,
-        powerTargetCpuOnly = saved.powerTargetCpuOnly,
-        gpuLocked = saved.gpuLocked,
-        gpuFloorPercent = saved.gpuFloorPercent,
-        cpuFloorPercent = saved.cpuFloorPercent,
-        primeCoreBoostLimited = saved.primeCoreBoostLimited,
-    )
+    fun afterCustomRestore(saved: CustomTuning): SideControlState = saved.sideControls
 
     // --- Individual side-control toggles (the per-control interlink matrix) ---
 

--- a/app/src/main/java/com/kei/pulse/overlay/QuickAccessState.kt
+++ b/app/src/main/java/com/kei/pulse/overlay/QuickAccessState.kt
@@ -7,6 +7,8 @@ import com.kei.pulse.model.FanTempController
 import com.kei.pulse.model.OverlayPreset
 import com.kei.pulse.model.PowerTier
 import com.kei.pulse.model.RgbMode
+import com.kei.pulse.model.toSideControlState
+import com.kei.pulse.model.withSideControls
 
 /** Rail tabs for the Quick Access Bar. */
 enum class QuickAccessTab { PERFORMANCE, FAN, RGB, OVERLAY, SYSTEM }
@@ -70,7 +72,12 @@ object QuickAccess {
             // Wired (2026-07-03): the service's applyQaPowerTarget computes the caps via the shared
             // PowerTargetMath and applies them with persistAsCustom — same path as the in-app slider.
             val pct = action.percent.coerceIn(POWER_TARGET_MIN, POWER_TARGET_MAX)
-            settings.copy(powerTargetPercent = pct, powerTargetEnabled = pct < POWER_TARGET_MAX)
+            settings.withSideControls(
+                settings.toSideControlState().copy(
+                    powerTargetPercent = pct,
+                    powerTargetEnabled = pct < POWER_TARGET_MAX,
+                ),
+            )
         }
         is QuickAccessAction.SetGpuCap ->
             settings // device + Custom-tuning write (applyQaGpuCap); not an AppSettings field

--- a/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
+++ b/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
@@ -446,15 +446,10 @@ class TunerViewModel(
 
     private fun persistTuning() {
         viewModelScope.launch {
+            val sideControls = currentSideControls()
             settingsStorage.persistTuningState(
-                powerTargetEnabled = _powerTargetEnabled.value,
-                powerTargetPercent = _powerTargetPercent.value,
-                powerTargetCpuOnly = _powerTargetCpuOnly.value,
-                gpuLocked = _gpuLocked.value,
-                gpuFloorPercent = _gpuFloorPercent.value,
-                cpuFloorPercent = _cpuFloorPercent.value,
+                sideControls = sideControls,
                 activeTierLabel = _activeTier.value.label,
-                primeCoreBoostLimited = _primeCoreBoostLimited.value,
             )
             // Snapshot the tuning knobs only while Custom is the active tier. Preset applies set
             // the tier to the preset before calling this, so they can't overwrite the Custom
@@ -462,7 +457,7 @@ class TunerViewModel(
             if (_activeTier.value == PowerTier.CUSTOM) {
                 settingsStorage.persistCustomTuning(
                     CustomTuning(
-                        sideControls = currentSideControls(),
+                        sideControls = sideControls,
                         // _governor holds the raw kernel name; store the option label so it
                         // round-trips back to an OPTIONS entry on restore.
                         governorLabel = GovernorController.optionForGovernor(_governor.value)?.label,

--- a/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
+++ b/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
@@ -37,6 +37,7 @@ import com.kei.pulse.model.ProfileStateResolver
 import com.kei.pulse.model.ProfileSource
 import com.kei.pulse.model.TileInteractionBehavior
 import com.kei.pulse.model.TunerState
+import com.kei.pulse.model.toSideControlState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -367,16 +368,10 @@ class TunerViewModel(
     init {
         viewModelScope.launch {
             val persisted = settingsStorage.settings.first()
-            _powerTargetEnabled.value = persisted.powerTargetEnabled
-            _powerTargetPercent.value = persisted.powerTargetPercent
-            _powerTargetCpuOnly.value = persisted.powerTargetCpuOnly
-            _gpuLocked.value = persisted.gpuLocked
-            _gpuFloorPercent.value = persisted.gpuFloorPercent
-            _cpuFloorPercent.value = persisted.cpuFloorPercent
+            applySideControls(persisted.toSideControlState())
             // Restore the active tier so the UI doesn't always reset to Custom
             PowerTier.entries.firstOrNull { it.label == persisted.activeTierLabel }
                 ?.let { _activeTier.value = it }
-            _primeCoreBoostLimited.value = persisted.primeCoreBoostLimited
             _learnedPeakW.value = persisted.learnedPeakW
             _autoTdpDefault.value = persisted.autoTdpDefaultEnabled
             _autoTdpFpsTarget.value = persisted.autoTdpFpsTarget

--- a/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
+++ b/app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt
@@ -462,13 +462,7 @@ class TunerViewModel(
             if (_activeTier.value == PowerTier.CUSTOM) {
                 settingsStorage.persistCustomTuning(
                     CustomTuning(
-                        powerTargetEnabled = _powerTargetEnabled.value,
-                        powerTargetPercent = _powerTargetPercent.value,
-                        powerTargetCpuOnly = _powerTargetCpuOnly.value,
-                        gpuLocked = _gpuLocked.value,
-                        gpuFloorPercent = _gpuFloorPercent.value,
-                        cpuFloorPercent = _cpuFloorPercent.value,
-                        primeCoreBoostLimited = _primeCoreBoostLimited.value,
+                        sideControls = currentSideControls(),
                         // _governor holds the raw kernel name; store the option label so it
                         // round-trips back to an OPTIONS entry on restore.
                         governorLabel = GovernorController.optionForGovernor(_governor.value)?.label,
@@ -640,26 +634,29 @@ class TunerViewModel(
      * (manual freqs, Power Target, prime boost) are already restored via the saved frequency map;
      * GPU min_pwrlevel gets widened by any apply, so a lock/floor must be re-pinned here.
      */
-    private suspend fun reapplyCustomSideControls(tuning: CustomTuning) {
+    private suspend fun reapplyCustomSideControls(sideControls: SideControlState) {
         val policies = state.value.policies
         val gpu = policies.firstOrNull { it.isGpu }
         withContext(Dispatchers.IO) {
             if (gpu != null) {
                 when {
-                    tuning.gpuLocked -> gpuFloorController.lockToCurrentCap(gpu.policyPath)
-                    tuning.gpuFloorPercent > 0 ->
-                        gpuFloorController.setFloorLevel(gpu.policyPath, gpuFloorLevelFor(gpu, tuning.gpuFloorPercent))
+                    sideControls.gpuLocked -> gpuFloorController.lockToCurrentCap(gpu.policyPath)
+                    sideControls.gpuFloorPercent > 0 ->
+                        gpuFloorController.setFloorLevel(
+                            gpu.policyPath,
+                            gpuFloorLevelFor(gpu, sideControls.gpuFloorPercent),
+                        )
                 }
             }
-            if (tuning.cpuFloorPercent > 0) {
-                cpuFloorController.setFloor(policies, tuning.cpuFloorPercent)
+            if (sideControls.cpuFloorPercent > 0) {
+                cpuFloorController.setFloor(policies, sideControls.cpuFloorPercent)
             }
             // Prime Boost Limit only governs when NO Power Target caps the prime — otherwise the PT's (lower)
             // prime cap must win. Without this gate the no-turbo write (e.g. 4204800) overwrites and 444-locks
             // the prime scaling_max that applyPowerTargetValues just set (e.g. 3072000 @ 69%), so the prime
             // reads back at 4.2 GHz instead of the Power Target value. PT governs the CPU clusters whenever it's
             // on (CPU-only still caps the CPU; only the GPU is freed), so the boost limit is redundant there.
-            if (tuning.primeCoreBoostLimited && !tuning.powerTargetEnabled) {
+            if (sideControls.primeCoreBoostLimited && !sideControls.powerTargetEnabled) {
                 val prime = policies.filterNot { it.isGpu }.maxByOrNull { it.selectableMaxFreq }
                 if (prime != null) {
                     val freqs = prime.supportedFrequencies
@@ -847,6 +844,7 @@ class TunerViewModel(
             // a preset apply clears or releases (Power Target toggle, GPU lock/floor, CPU floor).
             viewModelScope.launch {
                 val tuning = settingsStorage.customTuning.first()
+                val sideControls = tuning.sideControls
                 val result = repository.restoreCustomValues()
                 edits.value = emptyMap()
                 _activeTier.value = PowerTier.CUSTOM
@@ -857,8 +855,8 @@ class TunerViewModel(
                 // value map — otherwise the prior preset's CPU freqs keep showing in the current-values readout
                 // until the PT slider is nudged (the reported bug). Mirrors the slider path, and re-persists the
                 // reduced map so any stale saved values self-heal.
-                if (tuning.powerTargetEnabled) applyPowerTargetValues(tuning.powerTargetPercent)
-                reapplyCustomSideControls(tuning)
+                if (sideControls.powerTargetEnabled) applyPowerTargetValues(sideControls.powerTargetPercent)
+                reapplyCustomSideControls(sideControls)
                 // Restore the governor the user last set in Custom (if any).
                 tuning.governorLabel?.let { label ->
                     GovernorController.OPTIONS.firstOrNull { it.label == label }?.let { option ->

--- a/app/src/test/java/com/kei/pulse/appwatch/QuickAccessPowerTargetPersistenceTest.kt
+++ b/app/src/test/java/com/kei/pulse/appwatch/QuickAccessPowerTargetPersistenceTest.kt
@@ -1,0 +1,53 @@
+package com.kei.pulse.appwatch
+
+import com.kei.pulse.model.AppSettings
+import com.kei.pulse.model.CustomTuning
+import com.kei.pulse.model.SideControlState
+import com.kei.pulse.model.toSideControlState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QuickAccessPowerTargetPersistenceTest {
+    @Test
+    fun `power target edit preserves saved Custom controls cleared by a live preset`() {
+        val savedCustom = CustomTuning(
+            sideControls = SideControlState(
+                powerTargetEnabled = false,
+                powerTargetPercent = 100,
+                powerTargetCpuOnly = true,
+                gpuLocked = true,
+                gpuFloorPercent = 41,
+                cpuFloorPercent = 29,
+                primeCoreBoostLimited = true,
+            ),
+            governorLabel = "Performance",
+        )
+        val livePreset = AppSettings(
+            powerTargetEnabled = false,
+            powerTargetPercent = 100,
+            powerTargetCpuOnly = false,
+            gpuLocked = false,
+            gpuFloorPercent = 0,
+            cpuFloorPercent = 0,
+            primeCoreBoostLimited = false,
+            activeTierLabel = "Balanced",
+        )
+
+        val result = resolveQuickAccessPowerTargetPersistence(
+            settings = livePreset,
+            customTuning = savedCustom,
+            percent = 73,
+            enabled = true,
+        )
+
+        assertEquals(
+            livePreset.toSideControlState().copy(powerTargetEnabled = true, powerTargetPercent = 73),
+            result.liveSideControls,
+        )
+        assertEquals(
+            savedCustom.sideControls.copy(powerTargetEnabled = true, powerTargetPercent = 73),
+            result.customTuning.sideControls,
+        )
+        assertEquals("Performance", result.customTuning.governorLabel)
+    }
+}

--- a/app/src/test/java/com/kei/pulse/data/SettingsStorageApiTest.kt
+++ b/app/src/test/java/com/kei/pulse/data/SettingsStorageApiTest.kt
@@ -1,0 +1,15 @@
+package com.kei.pulse.data
+
+import com.kei.pulse.model.SideControlState
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class SettingsStorageApiTest {
+    @Test
+    fun `tuning persistence accepts one canonical snapshot plus tier`() {
+        val persist: suspend SettingsStorage.(SideControlState, String) -> Unit =
+            SettingsStorage::persistTuningState
+
+        assertNotNull(persist)
+    }
+}

--- a/app/src/test/java/com/kei/pulse/data/SideControlPreferencesTest.kt
+++ b/app/src/test/java/com/kei/pulse/data/SideControlPreferencesTest.kt
@@ -1,0 +1,39 @@
+package com.kei.pulse.data
+
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import com.kei.pulse.model.SideControlState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SideControlPreferencesTest {
+    private val engaged = SideControlState(
+        powerTargetEnabled = true,
+        powerTargetPercent = 73,
+        powerTargetCpuOnly = true,
+        gpuLocked = true,
+        gpuFloorPercent = 41,
+        cpuFloorPercent = 29,
+        primeCoreBoostLimited = true,
+    )
+
+    @Test
+    fun `live and Custom key sets round-trip every side-control field independently`() {
+        val preferences = mutablePreferencesOf()
+        val savedCustom = engaged.copy(powerTargetPercent = 67, gpuFloorPercent = 35)
+
+        preferences.putSideControls(LIVE_SIDE_CONTROL_KEYS, engaged)
+        preferences.putSideControls(CUSTOM_SIDE_CONTROL_KEYS, savedCustom)
+
+        assertEquals(engaged, preferences.readSideControls(LIVE_SIDE_CONTROL_KEYS))
+        assertEquals(savedCustom, preferences.readSideControls(CUSTOM_SIDE_CONTROL_KEYS))
+    }
+
+    @Test
+    fun `missing live and Custom keys restore neutral defaults`() {
+        val preferences = emptyPreferences()
+
+        assertEquals(SideControlState.CLEARED, preferences.readSideControls(LIVE_SIDE_CONTROL_KEYS))
+        assertEquals(SideControlState.CLEARED, preferences.readSideControls(CUSTOM_SIDE_CONTROL_KEYS))
+    }
+}

--- a/app/src/test/java/com/kei/pulse/model/SideControlStateMappingTest.kt
+++ b/app/src/test/java/com/kei/pulse/model/SideControlStateMappingTest.kt
@@ -1,0 +1,46 @@
+package com.kei.pulse.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SideControlStateMappingTest {
+    private val engaged = SideControlState(
+        powerTargetEnabled = true,
+        powerTargetPercent = 73,
+        powerTargetCpuOnly = true,
+        gpuLocked = true,
+        gpuFloorPercent = 41,
+        cpuFloorPercent = 29,
+        primeCoreBoostLimited = true,
+    )
+
+    @Test
+    fun `AppSettings exports every side-control field`() {
+        val settings = AppSettings(
+            powerTargetEnabled = true,
+            powerTargetPercent = 73,
+            powerTargetCpuOnly = true,
+            gpuLocked = true,
+            gpuFloorPercent = 41,
+            cpuFloorPercent = 29,
+            primeCoreBoostLimited = true,
+        )
+
+        assertEquals(engaged, settings.toSideControlState())
+    }
+
+    @Test
+    fun `AppSettings replaces every side-control field and preserves unrelated settings`() {
+        val before = AppSettings(accentColor = 0x12345678, activeTierLabel = "Balanced")
+        val after = before.withSideControls(engaged)
+
+        assertEquals(engaged, after.toSideControlState())
+        assertEquals(before.accentColor, after.accentColor)
+        assertEquals(before.activeTierLabel, after.activeTierLabel)
+    }
+
+    @Test
+    fun `neutral SideControlState matches the cleared alias`() {
+        assertEquals(SideControlState.CLEARED, SideControlState())
+    }
+}

--- a/app/src/test/java/com/kei/pulse/model/TierTransitionTest.kt
+++ b/app/src/test/java/com/kei/pulse/model/TierTransitionTest.kt
@@ -46,25 +46,11 @@ class TierTransitionTest {
     }
 
     @Test
-    fun `custom restore copies every saved knob`() {
-        val saved = CustomTuning(
-            powerTargetEnabled = true,
-            powerTargetPercent = 72,
-            powerTargetCpuOnly = true,
-            gpuLocked = true,
-            gpuFloorPercent = 55,
-            cpuFloorPercent = 25,
-            primeCoreBoostLimited = true,
-            governorLabel = "Performance",
-        )
-        val after = TierTransition.afterCustomRestore(saved)
-        assertEquals(saved.powerTargetEnabled, after.powerTargetEnabled)
-        assertEquals(saved.powerTargetPercent, after.powerTargetPercent)
-        assertEquals(saved.powerTargetCpuOnly, after.powerTargetCpuOnly)
-        assertEquals(saved.gpuLocked, after.gpuLocked)
-        assertEquals(saved.gpuFloorPercent, after.gpuFloorPercent)
-        assertEquals(saved.cpuFloorPercent, after.cpuFloorPercent)
-        assertEquals(saved.primeCoreBoostLimited, after.primeCoreBoostLimited)
+    fun `custom restore returns the complete saved side-control snapshot`() {
+        val saved = CustomTuning(sideControls = engaged, governorLabel = "Performance")
+
+        assertEquals(engaged, TierTransition.afterCustomRestore(saved))
+        assertEquals("Performance", saved.governorLabel)
     }
 
     @Test

--- a/app/src/test/java/com/kei/pulse/overlay/QuickAccessStateTest.kt
+++ b/app/src/test/java/com/kei/pulse/overlay/QuickAccessStateTest.kt
@@ -3,6 +3,7 @@ package com.kei.pulse.overlay
 import com.kei.pulse.data.FanController
 import com.kei.pulse.model.AppSettings
 import com.kei.pulse.model.AutoTdpBias
+import com.kei.pulse.model.toSideControlState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -56,10 +57,21 @@ class QuickAccessStateTest {
     }
 
     @Test
-    fun `set power target enables the cap and stores the percent`() {
-        val r = QuickAccess.reduce(base, QuickAccessAction.SetPowerTarget(85))
-        assertTrue(r.powerTargetEnabled)
-        assertEquals(85, r.powerTargetPercent)
+    fun `set power target changes only cap enablement and percent`() {
+        val before = base.copy(
+            powerTargetCpuOnly = true,
+            gpuLocked = true,
+            gpuFloorPercent = 41,
+            cpuFloorPercent = 29,
+            primeCoreBoostLimited = true,
+        )
+
+        val result = QuickAccess.reduce(before, QuickAccessAction.SetPowerTarget(85))
+
+        assertEquals(
+            before.toSideControlState().copy(powerTargetEnabled = true, powerTargetPercent = 85),
+            result.toSideControlState(),
+        )
     }
 
     @Test

--- a/docs/superpowers/plans/2026-07-11-side-control-state-consolidation.md
+++ b/docs/superpowers/plans/2026-07-11-side-control-state-consolidation.md
@@ -1,0 +1,569 @@
+# Side-Control State Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace repeated seven-field side-control plumbing with the canonical `SideControlState` value object without changing persistence keys, controller behavior, or user-visible behavior.
+
+**Architecture:** `AppSettings` remains flattened and gains two tested boundary adapters. `CustomTuning`, `SettingsStorage.persistTuningState()`, the ViewModel, and Quick Access pass one `SideControlState`; only `SettingsStorage` expands it into the existing Preferences keys and only the ViewModel expands it into existing UI flows.
+
+**Tech Stack:** Kotlin, Android Preferences DataStore, Kotlin coroutines/Flow, JUnit 4, Gradle Android unit tests.
+
+## Global Constraints
+
+- Existing Preferences DataStore keys and stored values remain unchanged; no data migration.
+- Governor selection, persistence, controller calls, and restoration behavior remain unchanged.
+- Device writes and their ordering remain unchanged.
+- Power-tier transition semantics remain unchanged.
+- Quick Access AutoTDP ownership guards and Custom-tier persistence behavior remain unchanged.
+- `AppSettings` keeps its seven flattened fields; broader nesting is a separate PR.
+- Work only in `/Users/joakimb/Projects/vibe/pulse/.worktrees/side-control-state-consolidation` on `codex/side-control-state-consolidation`.
+
+## File Map
+
+- Modify `app/src/main/java/com/kei/pulse/model/TierTransition.kt`: give `SideControlState` neutral defaults and return the embedded Custom snapshot directly.
+- Modify `app/src/main/java/com/kei/pulse/model/AppSettings.kt`: own the flattened-to-canonical boundary adapters.
+- Modify `app/src/main/java/com/kei/pulse/model/CustomTuning.kt`: compose `SideControlState` with the independently handled governor label.
+- Modify `app/src/main/java/com/kei/pulse/data/SettingsStorage.kt`: serialize the canonical object into the unchanged live and Custom Preferences keys.
+- Modify `app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt`: snapshot once, persist once, and read Custom side controls through the canonical object.
+- Modify `app/src/main/java/com/kei/pulse/overlay/QuickAccessState.kt`: route Power Target reduction through the AppSettings boundary adapters.
+- Modify `app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt`: persist and update complete canonical snapshots from Quick Access.
+- Create `app/src/test/java/com/kei/pulse/model/SideControlStateMappingTest.kt`: verify both AppSettings boundary directions and unrelated-field preservation.
+- Modify `app/src/test/java/com/kei/pulse/model/TierTransitionTest.kt`: verify composed Custom snapshots and unchanged transition behavior.
+- Create `app/src/test/java/com/kei/pulse/data/SettingsStorageApiTest.kt`: compile-check the canonical persistence signature.
+- Modify `app/src/test/java/com/kei/pulse/overlay/QuickAccessStateTest.kt`: compare the complete side-control snapshot after a Power Target reduction.
+
+---
+
+### Task 1: Add and adopt the AppSettings boundary adapters
+
+**Files:**
+- Modify: `app/src/main/java/com/kei/pulse/model/TierTransition.kt`
+- Modify: `app/src/main/java/com/kei/pulse/model/AppSettings.kt`
+- Modify: `app/src/main/java/com/kei/pulse/overlay/QuickAccessState.kt`
+- Create: `app/src/test/java/com/kei/pulse/model/SideControlStateMappingTest.kt`
+- Modify: `app/src/test/java/com/kei/pulse/overlay/QuickAccessStateTest.kt`
+
+**Interfaces:**
+- Produces: `AppSettings.toSideControlState(): SideControlState`
+- Produces: `AppSettings.withSideControls(sideControls: SideControlState): AppSettings`
+- Produces: `SideControlState()` as the neutral snapshot while retaining `SideControlState.CLEARED`
+
+- [ ] **Step 1: Write the failing AppSettings mapping tests**
+
+Create `SideControlStateMappingTest.kt`:
+
+```kotlin
+package com.kei.pulse.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SideControlStateMappingTest {
+    private val engaged = SideControlState(
+        powerTargetEnabled = true,
+        powerTargetPercent = 73,
+        powerTargetCpuOnly = true,
+        gpuLocked = true,
+        gpuFloorPercent = 41,
+        cpuFloorPercent = 29,
+        primeCoreBoostLimited = true,
+    )
+
+    @Test
+    fun `AppSettings exports every side-control field`() {
+        val settings = AppSettings(
+            powerTargetEnabled = true,
+            powerTargetPercent = 73,
+            powerTargetCpuOnly = true,
+            gpuLocked = true,
+            gpuFloorPercent = 41,
+            cpuFloorPercent = 29,
+            primeCoreBoostLimited = true,
+        )
+
+        assertEquals(engaged, settings.toSideControlState())
+    }
+
+    @Test
+    fun `AppSettings replaces every side-control field and preserves unrelated settings`() {
+        val before = AppSettings(accentColor = 0x12345678, activeTierLabel = "Balanced")
+        val after = before.withSideControls(engaged)
+
+        assertEquals(engaged, after.toSideControlState())
+        assertEquals(before.accentColor, after.accentColor)
+        assertEquals(before.activeTierLabel, after.activeTierLabel)
+    }
+
+    @Test
+    fun `neutral SideControlState matches the cleared alias`() {
+        assertEquals(SideControlState.CLEARED, SideControlState())
+    }
+}
+```
+
+- [ ] **Step 2: Run the mapping test and verify RED**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.model.SideControlStateMappingTest
+```
+
+Expected: compilation fails because `toSideControlState()`, `withSideControls()`, and the zero-argument `SideControlState()` do not exist.
+
+- [ ] **Step 3: Implement the canonical defaults and AppSettings adapters**
+
+Change `SideControlState` in `TierTransition.kt` to:
+
+```kotlin
+data class SideControlState(
+    val powerTargetEnabled: Boolean = false,
+    val powerTargetPercent: Int = 100,
+    val powerTargetCpuOnly: Boolean = false,
+    val gpuLocked: Boolean = false,
+    val gpuFloorPercent: Int = 0,
+    val cpuFloorPercent: Int = 0,
+    val primeCoreBoostLimited: Boolean = false,
+) {
+    companion object {
+        /** All side-controls at their neutral defaults (nothing governing). */
+        val CLEARED = SideControlState()
+    }
+}
+```
+
+Append these model-boundary functions after `AppSettings` in `AppSettings.kt`:
+
+```kotlin
+fun AppSettings.toSideControlState(): SideControlState = SideControlState(
+    powerTargetEnabled = powerTargetEnabled,
+    powerTargetPercent = powerTargetPercent,
+    powerTargetCpuOnly = powerTargetCpuOnly,
+    gpuLocked = gpuLocked,
+    gpuFloorPercent = gpuFloorPercent,
+    cpuFloorPercent = cpuFloorPercent,
+    primeCoreBoostLimited = primeCoreBoostLimited,
+)
+
+fun AppSettings.withSideControls(sideControls: SideControlState): AppSettings = copy(
+    powerTargetEnabled = sideControls.powerTargetEnabled,
+    powerTargetPercent = sideControls.powerTargetPercent,
+    powerTargetCpuOnly = sideControls.powerTargetCpuOnly,
+    gpuLocked = sideControls.gpuLocked,
+    gpuFloorPercent = sideControls.gpuFloorPercent,
+    cpuFloorPercent = sideControls.cpuFloorPercent,
+    primeCoreBoostLimited = sideControls.primeCoreBoostLimited,
+)
+```
+
+- [ ] **Step 4: Run the mapping test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: `SideControlStateMappingTest` passes.
+
+- [ ] **Step 5: Strengthen the Quick Access characterization test**
+
+Replace the Power Target test body in `QuickAccessStateTest.kt` with a whole-snapshot assertion and add the import:
+
+```kotlin
+import com.kei.pulse.model.toSideControlState
+```
+
+```kotlin
+@Test
+fun `set power target changes only cap enablement and percent`() {
+    val before = base.copy(
+        powerTargetCpuOnly = true,
+        gpuLocked = true,
+        gpuFloorPercent = 41,
+        cpuFloorPercent = 29,
+        primeCoreBoostLimited = true,
+    )
+
+    val result = QuickAccess.reduce(before, QuickAccessAction.SetPowerTarget(85))
+
+    assertEquals(
+        before.toSideControlState().copy(powerTargetEnabled = true, powerTargetPercent = 85),
+        result.toSideControlState(),
+    )
+}
+```
+
+- [ ] **Step 6: Run the Quick Access characterization test**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.overlay.QuickAccessStateTest
+```
+
+Expected: PASS before the internal refactor, proving current behavior is pinned.
+
+- [ ] **Step 7: Refactor Quick Access to use the boundary adapters**
+
+Add imports in `QuickAccessState.kt`:
+
+```kotlin
+import com.kei.pulse.model.toSideControlState
+import com.kei.pulse.model.withSideControls
+```
+
+Replace the `SetPowerTarget` branch with:
+
+```kotlin
+is QuickAccessAction.SetPowerTarget -> {
+    val pct = action.percent.coerceIn(POWER_TARGET_MIN, POWER_TARGET_MAX)
+    settings.withSideControls(
+        settings.toSideControlState().copy(
+            powerTargetPercent = pct,
+            powerTargetEnabled = pct < POWER_TARGET_MAX,
+        ),
+    )
+}
+```
+
+- [ ] **Step 8: Run focused tests and commit**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.model.SideControlStateMappingTest --tests com.kei.pulse.overlay.QuickAccessStateTest
+```
+
+Expected: both test classes pass.
+
+Commit:
+
+```bash
+git add app/src/main/java/com/kei/pulse/model/TierTransition.kt app/src/main/java/com/kei/pulse/model/AppSettings.kt app/src/main/java/com/kei/pulse/overlay/QuickAccessState.kt app/src/test/java/com/kei/pulse/model/SideControlStateMappingTest.kt app/src/test/java/com/kei/pulse/overlay/QuickAccessStateTest.kt
+git commit -m "refactor: add canonical side-control adapters"
+```
+
+---
+
+### Task 2: Compose the Custom tuning snapshot
+
+**Files:**
+- Modify: `app/src/main/java/com/kei/pulse/model/CustomTuning.kt`
+- Modify: `app/src/main/java/com/kei/pulse/model/TierTransition.kt`
+- Modify: `app/src/main/java/com/kei/pulse/data/SettingsStorage.kt`
+- Modify: `app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt`
+- Modify: `app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt`
+- Modify: `app/src/test/java/com/kei/pulse/model/TierTransitionTest.kt`
+
+**Interfaces:**
+- Consumes: `SideControlState` and `AppSettings.toSideControlState()` from Task 1
+- Produces: `CustomTuning(sideControls: SideControlState = SideControlState(), governorLabel: String? = null)`
+- Produces: `TierTransition.afterCustomRestore(saved)` as a direct return of `saved.sideControls`
+
+- [ ] **Step 1: Rewrite the Custom restoration test for composition**
+
+Replace `custom restore copies every saved knob` in `TierTransitionTest.kt` with:
+
+```kotlin
+@Test
+fun `custom restore returns the complete saved side-control snapshot`() {
+    val saved = CustomTuning(sideControls = engaged, governorLabel = "Performance")
+
+    assertEquals(engaged, TierTransition.afterCustomRestore(saved))
+    assertEquals("Performance", saved.governorLabel)
+}
+```
+
+Keep `custom restore of default tuning yields the cleared state`; it will verify the composed default.
+
+- [ ] **Step 2: Run the transition test and verify RED**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.model.TierTransitionTest
+```
+
+Expected: compilation fails because `CustomTuning` has no `sideControls` parameter.
+
+- [ ] **Step 3: Replace duplicated CustomTuning fields with composition**
+
+Replace the data class in `CustomTuning.kt` with:
+
+```kotlin
+data class CustomTuning(
+    val sideControls: SideControlState = SideControlState(),
+    /** GovernorController.OPTIONS label the user last chose while in Custom; null = leave alone. */
+    val governorLabel: String? = null,
+)
+```
+
+Replace `TierTransition.afterCustomRestore()` with:
+
+```kotlin
+fun afterCustomRestore(saved: CustomTuning): SideControlState = saved.sideControls
+```
+
+- [ ] **Step 4: Update Custom Preferences serialization without changing keys**
+
+In `SettingsStorage.kt`, add the `SideControlState` import. Construct `CustomTuning` as:
+
+```kotlin
+CustomTuning(
+    sideControls = SideControlState(
+        powerTargetEnabled = preferences[customPtEnabledKey] ?: false,
+        powerTargetPercent = preferences[customPtPercentKey] ?: 100,
+        powerTargetCpuOnly = preferences[customPtCpuOnlyKey] ?: false,
+        gpuLocked = preferences[customGpuLockedKey] ?: false,
+        gpuFloorPercent = preferences[customGpuFloorKey] ?: 0,
+        cpuFloorPercent = preferences[customCpuFloorKey] ?: 0,
+        primeCoreBoostLimited = preferences[customPrimeBoostKey] ?: false,
+    ),
+    governorLabel = preferences[customGovernorLabelKey],
+)
+```
+
+Start `persistCustomTuning()` with `val sideControls = tuning.sideControls`, then keep the same seven assignments using `sideControls.<field>`. Leave the governor key write/remove block unchanged.
+
+- [ ] **Step 5: Update ViewModel Custom snapshot consumers**
+
+In `persistTuning()`, replace the scalar `CustomTuning` construction with:
+
+```kotlin
+CustomTuning(
+    sideControls = currentSideControls(),
+    governorLabel = GovernorController.optionForGovernor(_governor.value)?.label,
+)
+```
+
+Change `reapplyCustomSideControls` to accept `sideControls: SideControlState` and replace each `tuning.<field>` access with `sideControls.<field>`. At restoration, use:
+
+```kotlin
+val sideControls = tuning.sideControls
+applySideControls(TierTransition.afterCustomRestore(tuning))
+if (sideControls.powerTargetEnabled) applyPowerTargetValues(sideControls.powerTargetPercent)
+reapplyCustomSideControls(sideControls)
+```
+
+Do not change the following governor block or any device-controller call ordering.
+
+- [ ] **Step 6: Update the Quick Access Custom snapshot copy**
+
+In `ForegroundAppMonitorService.applyQaPowerTarget()`, replace the scalar `CustomTuning.copy()` call with:
+
+```kotlin
+val customTuning = store.customTuning.first()
+store.persistCustomTuning(
+    customTuning.copy(
+        sideControls = customTuning.sideControls.copy(
+            powerTargetEnabled = enabled,
+            powerTargetPercent = percent,
+        ),
+    ),
+)
+```
+
+- [ ] **Step 7: Run focused and full unit tests**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.model.TierTransitionTest --tests com.kei.pulse.model.SideControlStateMappingTest
+./gradlew testDebugUnitTest
+```
+
+Expected: focused tests pass, followed by a successful full unit-test build.
+
+- [ ] **Step 8: Commit the composed Custom snapshot**
+
+```bash
+git add app/src/main/java/com/kei/pulse/model/CustomTuning.kt app/src/main/java/com/kei/pulse/model/TierTransition.kt app/src/main/java/com/kei/pulse/data/SettingsStorage.kt app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt app/src/test/java/com/kei/pulse/model/TierTransitionTest.kt
+git commit -m "refactor: compose custom side-control state"
+```
+
+---
+
+### Task 3: Consolidate live tuning persistence
+
+**Files:**
+- Modify: `app/src/main/java/com/kei/pulse/data/SettingsStorage.kt`
+- Modify: `app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt`
+- Modify: `app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt`
+- Create: `app/src/test/java/com/kei/pulse/data/SettingsStorageApiTest.kt`
+
+**Interfaces:**
+- Consumes: `SideControlState` and `AppSettings.toSideControlState()` from Task 1
+- Produces: `suspend fun SettingsStorage.persistTuningState(sideControls: SideControlState, activeTierLabel: String)`
+
+- [ ] **Step 1: Add a compile-time API test for the canonical signature**
+
+Create `SettingsStorageApiTest.kt`:
+
+```kotlin
+package com.kei.pulse.data
+
+import com.kei.pulse.model.SideControlState
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class SettingsStorageApiTest {
+    @Test
+    fun `tuning persistence accepts one canonical snapshot plus tier`() {
+        val persist: suspend SettingsStorage.(SideControlState, String) -> Unit =
+            SettingsStorage::persistTuningState
+
+        assertNotNull(persist)
+    }
+}
+```
+
+- [ ] **Step 2: Run the API test and verify RED**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.data.SettingsStorageApiTest
+```
+
+Expected: test compilation fails because the current eight-scalar method does not match the declared function type.
+
+- [ ] **Step 3: Replace the scalar persistence API**
+
+Replace `persistTuningState()` in `SettingsStorage.kt` with:
+
+```kotlin
+suspend fun persistTuningState(
+    sideControls: SideControlState,
+    activeTierLabel: String,
+) {
+    withContext(NonCancellable) { context.settingsDataStore.edit { preferences ->
+        preferences[powerTargetEnabledKey] = sideControls.powerTargetEnabled
+        preferences[powerTargetPercentKey] = sideControls.powerTargetPercent
+        preferences[powerTargetCpuOnlyKey] = sideControls.powerTargetCpuOnly
+        preferences[gpuLockedKey] = sideControls.gpuLocked
+        preferences[gpuFloorPercentKey] = sideControls.gpuFloorPercent
+        preferences[cpuFloorPercentKey] = sideControls.cpuFloorPercent
+        preferences[activeTierKey] = activeTierLabel
+        preferences[primeCoreBoostKey] = sideControls.primeCoreBoostLimited
+    } }
+}
+```
+
+- [ ] **Step 4: Update the ViewModel call site**
+
+At the start of the `persistTuning()` coroutine, take one snapshot and reuse it for both writes:
+
+```kotlin
+val sideControls = currentSideControls()
+settingsStorage.persistTuningState(
+    sideControls = sideControls,
+    activeTierLabel = _activeTier.value.label,
+)
+```
+
+Use that same `sideControls` in `CustomTuning(sideControls = sideControls, ...)`. This ensures the live and Custom writes cannot observe seven flows at different moments.
+
+- [ ] **Step 5: Update the Quick Access call site**
+
+Add the `toSideControlState` import in `ForegroundAppMonitorService.kt`. Replace the scalar call with:
+
+```kotlin
+val sideControls = s.toSideControlState().copy(
+    powerTargetEnabled = enabled,
+    powerTargetPercent = percent,
+)
+store.persistTuningState(
+    sideControls = sideControls,
+    activeTierLabel = PowerTier.CUSTOM.label,
+)
+```
+
+Update only the edited fields on the independently saved Custom snapshot:
+
+```kotlin
+val customTuning = store.customTuning.first()
+store.persistCustomTuning(
+    customTuning.copy(
+        sideControls = customTuning.sideControls.copy(
+            powerTargetEnabled = enabled,
+            powerTargetPercent = percent,
+        ),
+    ),
+)
+```
+
+This intentionally matches the existing behavior: the live snapshot starts from current `AppSettings`, while the saved Custom snapshot starts from `customTuning.sideControls`. A preset may have cleared live GPU/floor/boost controls, so replacing the saved Custom snapshot with the live one would silently erase values that must return when Custom is restored. The governor label is retained by `copy()`.
+
+- [ ] **Step 6: Run the API test and full unit tests**
+
+Run:
+
+```bash
+./gradlew testDebugUnitTest --tests com.kei.pulse.data.SettingsStorageApiTest
+./gradlew testDebugUnitTest
+```
+
+Expected: the API test passes and the full unit-test build succeeds.
+
+- [ ] **Step 7: Confirm duplicated scalar calls are gone**
+
+Run:
+
+```bash
+rg -n "persistTuningState\(" app/src/main/java app/src/test
+```
+
+Expected: one declaration and two call sites, each passing `sideControls` and `activeTierLabel`; no seven-field scalar call remains.
+
+- [ ] **Step 8: Commit live persistence consolidation**
+
+```bash
+git add app/src/main/java/com/kei/pulse/data/SettingsStorage.kt app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt app/src/test/java/com/kei/pulse/data/SettingsStorageApiTest.kt
+git commit -m "refactor: persist canonical side-control state"
+```
+
+---
+
+### Task 4: Verify scope and behavior end to end
+
+**Files:**
+- Verify only; no source changes expected.
+
+**Interfaces:**
+- Consumes: all interfaces produced by Tasks 1–3
+- Produces: evidence that unit tests and the debug build pass and that broader follow-up work stayed out of scope
+
+- [ ] **Step 1: Run the complete verification command**
+
+```bash
+./gradlew testDebugUnitTest assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL` with no failed tests or compilation errors. Existing Gradle/Android deprecation warnings are baseline warnings and do not fail this task.
+
+- [ ] **Step 2: Audit the seven-field duplication boundary**
+
+```bash
+rg -n "powerTargetEnabled|powerTargetPercent|powerTargetCpuOnly|gpuLocked|gpuFloorPercent|cpuFloorPercent|primeCoreBoostLimited" app/src/main/java/com/kei/pulse/model/CustomTuning.kt app/src/main/java/com/kei/pulse/data/SettingsStorage.kt app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+```
+
+Expected:
+
+- `CustomTuning.kt` contains only `sideControls`, not seven properties.
+- `SettingsStorage.kt` expands fields only at the two intentional Preferences serialization boundaries.
+- `TunerViewModel.kt` expands fields only in `currentSideControls()`, `applySideControls()`, and device-control reads.
+- `ForegroundAppMonitorService.kt` updates one copied `SideControlState`; it has no scalar `persistTuningState()` call.
+
+- [ ] **Step 3: Audit compatibility constraints**
+
+```bash
+git diff 3971244 -- app/src/main/java/com/kei/pulse/data/SettingsStorage.kt app/src/main/java/com/kei/pulse/ui/TunerViewModel.kt app/src/main/java/com/kei/pulse/appwatch/ForegroundAppMonitorService.kt
+```
+
+Expected: no Preferences key names change; governor blocks and device-controller call ordering are unchanged; changes are limited to snapshot construction, access, and persistence parameters.
+
+- [ ] **Step 4: Confirm a clean worktree and review the commit series**
+
+```bash
+git status --short
+git log --oneline 3971244..HEAD
+```
+
+Expected: clean status and three focused refactor commits corresponding to Tasks 1–3.

--- a/docs/superpowers/specs/2026-07-11-side-control-state-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-11-side-control-state-consolidation-design.md
@@ -1,0 +1,128 @@
+# Side-Control State Consolidation
+
+## Summary
+
+Consolidate the seven simple side-control fields into the existing `SideControlState` value object wherever they currently travel together. This is a representation and plumbing refactor only. It prevents persistence and restoration omissions by replacing repeated scalar argument lists and hand-written field copies with one typed value.
+
+The seven fields are:
+
+- `powerTargetEnabled`
+- `powerTargetPercent`
+- `powerTargetCpuOnly`
+- `gpuLocked`
+- `gpuFloorPercent`
+- `cpuFloorPercent`
+- `primeCoreBoostLimited`
+
+## Goals
+
+- Make `SideControlState` the canonical transfer type for these seven values.
+- Remove duplicated seven-field construction and parameter lists from `CustomTuning`, `persistTuningState()`, the ViewModel, and Quick Access.
+- Reduce future side-control additions to a few explicit, round-trip-tested storage/model boundaries instead of repeated hand-written plumbing across consumers.
+- Preserve all existing user-visible and device-control behavior.
+
+## Compatibility Constraints
+
+This refactor must leave the following unchanged:
+
+- Existing Preferences DataStore keys and stored values. No data migration is required.
+- Governor selection, persistence, controller calls, and restoration behavior.
+- Device writes and their ordering.
+- Power-tier transition semantics.
+- Quick Access behavior, including its AutoTDP ownership guard and Custom-tier persistence behavior.
+- The flattened public shape of `AppSettings` outside the new boundary adapters.
+
+## Design
+
+### Canonical value object
+
+`SideControlState` remains the canonical seven-field value object. Its fields receive the current neutral defaults so `SideControlState()` represents the cleared state; `CLEARED` may remain as a readable alias if useful at call sites.
+
+`TierTransition` continues to accept and return `SideControlState`. Preset clearing and individual interlink rules remain unchanged.
+
+### Custom tuning snapshot
+
+Replace the seven duplicated properties in `CustomTuning` with:
+
+```kotlin
+data class CustomTuning(
+    val sideControls: SideControlState = SideControlState(),
+    val governorLabel: String? = null,
+)
+```
+
+The governor stays separate because it is restored through `GovernorController` rather than applied as a simple side-control flag.
+
+### AppSettings boundary
+
+Keep the seven persisted properties flattened in `AppSettings`. Add two explicit model-boundary helpers:
+
+- `AppSettings.toSideControlState()` returns the canonical snapshot.
+- `AppSettings.withSideControls(state)` returns a copy with all seven flattened properties replaced from the snapshot.
+
+This is the one intentional mapping boundary between the broad settings model and the focused value object. Both directions receive round-trip tests with distinct values.
+
+### Persistence boundary
+
+Change live tuning persistence from eight scalar arguments to:
+
+```kotlin
+suspend fun persistTuningState(
+    sideControls: SideControlState,
+    activeTierLabel: String,
+)
+```
+
+`SettingsStorage` continues to write the same seven Preferences keys. Custom tuning reads and writes `CustomTuning.sideControls` against the existing `custom_*` keys. Nullable governor-key handling remains unchanged.
+
+The explicit key assignments are retained inside `SettingsStorage`; they are the necessary serialization boundary, not duplicated business-state plumbing.
+
+### ViewModel
+
+The ViewModel keeps its existing individual `StateFlow` properties so the UI API and recomposition behavior remain stable.
+
+- `currentSideControls()` remains the single flow-to-value-object adapter.
+- `applySideControls()` remains the single value-object-to-flow adapter.
+- `persistTuning()` passes `currentSideControls()` directly to both live tuning persistence and the Custom snapshot.
+- Custom restoration passes `CustomTuning.sideControls` directly through `TierTransition` and `applySideControls()`.
+
+No device-controller calls or coroutine ordering change.
+
+### Quick Access
+
+Quick Access continues to receive and reduce `AppSettings`. Any side-control edit uses `toSideControlState()`, copies the changed field on that value, and uses `withSideControls()` when an updated `AppSettings` is needed.
+
+The foreground service passes the complete canonical value to `persistTuningState()` and updates the Custom snapshot with the same value. Its existing clock-write, AutoTDP guard, bound-cap recapture, and logging behavior remain unchanged.
+
+## Testing
+
+Implementation follows test-driven development. Tests should first fail against the duplicated API, then pass after consolidation.
+
+Required coverage:
+
+- `AppSettings.toSideControlState()` copies all seven distinct non-default values.
+- `AppSettings.withSideControls()` replaces all seven values while preserving unrelated settings.
+- Converting `AppSettings` to side controls and back round-trips all seven values.
+- `CustomTuning` defaults to cleared side controls and retains its governor label independently.
+- Preset clearing and Custom restoration retain the existing `TierTransition` behavior.
+- Quick Access Power Target reduction changes only the intended side-control values.
+- Existing model and Quick Access tests remain green.
+
+Where practical, assertions compare the whole `SideControlState` rather than seven independent assertions. This makes an added field participate in equality and exposes incomplete mappings.
+
+## Follow-up PR Candidates
+
+The following are worthwhile improvements but are intentionally outside this PR:
+
+1. **Compose side controls into `AppSettings`.** Replace its seven flattened fields with a nested `SideControlState` throughout the application. This would remove the final model adapter but has broad call-site, `copy()`, UI, and service impact and should be reviewed independently.
+2. **Review governor state as part of a broader tuning snapshot.** Explore whether governor persistence and restoration should share a higher-level Custom tuning transaction with the simple side controls. This touches controller-specific behavior and ordering, so it should not be bundled with a structural omission-prevention refactor.
+3. **Review runtime tuning transactions.** Consider whether device writes, live state persistence, and Custom snapshot persistence should be represented as one explicit operation. That could improve atomicity but changes failure and concurrency semantics and requires separate behavioral design and testing.
+
+## Non-goals
+
+- Changing settings defaults or validation.
+- Renaming Preferences keys or migrating stored data.
+- Changing UI controls or their public ViewModel flows.
+- Changing governor or device-controller behavior.
+- Changing Quick Access scope, AutoTDP, or per-app routing.
+- Addressing unrelated settings duplication.

--- a/docs/superpowers/specs/2026-07-11-side-control-state-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-11-side-control-state-consolidation-design.md
@@ -92,7 +92,7 @@ No device-controller calls or coroutine ordering change.
 
 Quick Access continues to receive and reduce `AppSettings`. Any side-control edit uses `toSideControlState()`, copies the changed field on that value, and uses `withSideControls()` when an updated `AppSettings` is needed.
 
-The foreground service passes the complete canonical value to `persistTuningState()` and updates the Custom snapshot with the same value. Its existing clock-write, AutoTDP guard, bound-cap recapture, and logging behavior remain unchanged.
+The foreground service passes the complete live canonical value to `persistTuningState()`. It updates only the edited fields on the independently saved Custom snapshot, preserving Custom GPU/floor/boost values that a live preset may have cleared. Its existing clock-write, AutoTDP guard, bound-cap recapture, and logging behavior remain unchanged.
 
 ## Testing
 


### PR DESCRIPTION
## Problem

The seven side-control tuning fields were copied independently across tier transitions, Custom snapshots, live persistence, the ViewModel, and Quick Access. Adding or restoring a field required updating several scalar argument lists and hand-written mappings, making silent persistence or restoration omissions easy.

## Root cause

There was no canonical transfer object across these boundaries. `SideControlState` existed for tier transitions, but `CustomTuning`, `persistTuningState()`, startup restoration, and Quick Access still reconstructed the same values independently.

## Changes

- make `SideControlState` the canonical seven-field transfer object
- add tested `AppSettings` adapters while preserving its flattened public shape
- compose `CustomTuning` from `SideControlState` plus the separately handled governor label
- replace the scalar live-persistence API with one canonical snapshot and tier label
- reuse one ViewModel snapshot for live and Custom persistence
- route startup restoration and Quick Access Power Target updates through the shared adapters
- preserve independently saved Custom controls when a live preset has cleared them
- retain all existing Preferences keys, governor handling, device writes, and transition ordering
- add mapping, restoration, Quick Access, Preferences round-trip, and persistence-API regression coverage

## User impact

Custom tuning values now move through one omission-resistant contract, reducing the chance that a future side-control addition is persisted but not restored, or updated in the app but omitted from Quick Access. Existing saved settings and runtime behavior remain unchanged.

## Validation

- `./gradlew testDebugUnitTest assembleDebug lintDebug`
- unit coverage includes complete AppSettings round trips, unrelated-setting preservation, Custom restoration, Quick Access preservation of preset-cleared Custom controls, live and Custom Preferences round trips, missing-key defaults, and the canonical persistence signature
- hardware validation has not been performed by the contributor

## AI assistance disclosure

This change was created with assistance from ChatGPT using the GPT-5 model. The contributor reviewed the resulting code and ran the validation listed above.
